### PR TITLE
各種インフラ コンポーネントのバージョンアップ

### DIFF
--- a/deploy-tools/infra/conf/group_vars/all.yml
+++ b/deploy-tools/infra/conf/group_vars/all.yml
@@ -1,10 +1,10 @@
 # KQIクラスタのデフォルト構成
-nvidia_device_plugin_version: v1.12
+nvidia_device_plugin_version: 1.0.0-beta
 nvidia_driver: nvidia-384
 install_nvidia_driver: false
 nvidia_docker_packages:
-    - nvidia-container-runtime=2.0.0+docker18.06.2-1
-    - nvidia-docker2=2.0.3+docker18.06.2-1
+    - nvidia-container-runtime=2.0.0+docker18.09.6-3
+    - nvidia-docker2=2.0.3+docker18.09.6-3
 
 ansible_python_interpreter: /usr/bin/python3
 

--- a/deploy-tools/infra/deploy-kqi-infra.sh
+++ b/deploy-tools/infra/deploy-kqi-infra.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly KUBESPLAY_VERSION="v2.8.4"
+readonly KUBESPLAY_VERSION="v2.10.0"
 readonly SCRIPT_DIR=$(cd $(dirname $0); pwd)
 readonly REPO_ROOT_DIR="$SCRIPT_DIR/../.."
 

--- a/deploy-tools/kamonohashi/deploy-kqi.sh
+++ b/deploy-tools/kamonohashi/deploy-kqi.sh
@@ -9,7 +9,7 @@ show_help() {
 
 prepare(){
     # helmのインストール
-    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash /dev/stdin --version v2.7.2
+    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash /dev/stdin --version v2.13.0
     kubectl create -f helm-rbac-config.yml
     helm init --service-account tiller --upgrade
     # kqi-system namespaceの作成


### PR DESCRIPTION
kubecpray 2.8.xではcoreDNSが大量に立つので、バージョンアップして回避する