### PR TITLE
テナントロール設定部の表示を修正

### DIFF
--- a/web-pages/src/components/system-setting/user/TenantRoleSelector.vue
+++ b/web-pages/src/components/system-setting/user/TenantRoleSelector.vue
@@ -24,10 +24,10 @@
       <el-table :data="tenantRoles">
         <el-table-column prop="displayName" label="テナント名" width="200px">
           <template slot-scope="prop">
-            <el-checkbox v-model="prop.row.default" @change="handleDefaultChange(prop.row)">
+            <el-radio v-model="prop.row.default" :label="true" @change="handleDefaultChange(prop.row)" style="display: block;">
               {{prop.row.displayName}}
               <span v-if="prop.row.default" style="font-size:0.7rem;">(デフォルト)</span>
-            </el-checkbox>
+            </el-radio>
           </template>
         </el-table-column>
         <el-table-column label="ロール" width="auto">


### PR DESCRIPTION
ユーザ管理画面のテナントロール設定部の表示を修正しました。
- チェックボックスからラジオボタンに変更
- レイアウト一部修正

ご確認をお願いします。