### PR TITLE
10000年以上の検索時、最大日付を指定するように修正

### DIFF
--- a/web-pages/src/components/common/SmartSearchInput/InputDate.vue
+++ b/web-pages/src/components/common/SmartSearchInput/InputDate.vue
@@ -82,6 +82,10 @@ export default {
       }
 
       var y = dt.getFullYear()
+      if (y >= 10000) {
+        // 10000年以上の場合、最大日付を返す
+        return '9999/12/31'
+      }
       var m = ('00' + (dt.getMonth() + 1)).slice(-2)
       var d = ('00' + dt.getDate()).slice(-2)
       var result = y + '/' + m + '/' + d


### PR DESCRIPTION
検索時、10000年以上の日付を指定すると正しく検索されなかったため、
最大日付を指定するように修正しました。

ご確認をお願いします。