### PR TITLE
リソース管理画面の表示を修正

### DIFF
--- a/web-api/platypus/platypus/ApiModels/ResourceApiModels/NodeResourceOutputModel.cs
+++ b/web-api/platypus/platypus/ApiModels/ResourceApiModels/NodeResourceOutputModel.cs
@@ -162,8 +162,8 @@ namespace Nssol.Platypus.ApiModels.ResourceApiModels
 
         public void Add(ContainerDetailsOutputModel model)
         {
-            AssignedCpu += model.Cpu;
-            AssignedMemory += model.Memory;
+            AssignedCpu = Util.SumOfFloat(AssignedCpu, model.Cpu);
+            AssignedMemory = Util.SumOfFloat(AssignedMemory, model.Memory);
             AssignedGpu += model.Gpu;
             ContainerResourceList.Add(model);
         }
@@ -173,8 +173,8 @@ namespace Nssol.Platypus.ApiModels.ResourceApiModels
         /// </summary>
         public void IncrementData(ContainerDetailsOutputModel model)
         {
-            AssignedCpu += model.Cpu;
-            AssignedMemory += model.Memory;
+            AssignedCpu = Util.SumOfFloat(AssignedCpu, model.Cpu);
+            AssignedMemory = Util.SumOfFloat(AssignedMemory, model.Memory);
             AssignedGpu += model.Gpu;
         }
     }

--- a/web-api/platypus/platypus/ApiModels/ResourceApiModels/TenantResourceOutputModel.cs
+++ b/web-api/platypus/platypus/ApiModels/ResourceApiModels/TenantResourceOutputModel.cs
@@ -1,4 +1,5 @@
-﻿using Nssol.Platypus.Models;
+﻿using Nssol.Platypus.Infrastructure;
+using Nssol.Platypus.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -118,8 +119,8 @@ namespace Nssol.Platypus.ApiModels.ResourceApiModels
         {
             model.TenantId = Id;
 
-            AssignedCpu += model.Cpu;
-            AssignedMemory += model.Memory;
+            AssignedCpu = Util.SumOfFloat(AssignedCpu, model.Cpu);
+            AssignedMemory = Util.SumOfFloat(AssignedMemory, model.Memory);
             AssignedGpu += model.Gpu;
             ContainerResourceList.Add(model);
         }

--- a/web-api/platypus/platypus/Infrastructure/Util.cs
+++ b/web-api/platypus/platypus/Infrastructure/Util.cs
@@ -221,5 +221,15 @@ namespace Nssol.Platypus.Infrastructure
             }
             return result.ToString();
         }
+
+        /// <summary>
+        /// 2つのfloat型の和を求める。
+        /// </summary>
+        /// <param name="fp1">float型の値1</param>
+        /// <param name="fp2">float型の値2</param>
+        public static float SumOfFloat(float fp1, float fp2)
+        {
+            return (float)((decimal)fp1 + (decimal)fp2);
+        }
     }
 }

--- a/web-pages/src/components/system-setting/cluster-resource/Edit.vue
+++ b/web-pages/src/components/system-setting/cluster-resource/Edit.vue
@@ -149,7 +149,13 @@
             name: this.name
           }
           let content = (await api.resource.admin.getContainerLogByName(params)).data
-          this.filename = this.form.node + '_' + this.form.tenant + '_' + this.form.name + '.log'
+
+          if (!this.form.node) {
+            // ノードが振り分けられていない場合
+            this.filename = this.form.tenant + '_' + this.form.name + '.log'
+          } else {
+            this.filename = this.form.node + '_' + this.form.tenant + '_' + this.form.name + '.log'
+          }
 
           let a = document.getElementById('download')
           a.download = this.filename

--- a/web-pages/src/components/system-setting/cluster-resource/Edit.vue
+++ b/web-pages/src/components/system-setting/cluster-resource/Edit.vue
@@ -40,7 +40,7 @@
           </el-collapse>
         </div>
 
-        <el-form-item label="ログ">
+        <el-form-item label="ログ" v-if="this.form.node">
           <br clear="all"/>
           <span v-if="!filename">
             <el-button icon="el-icon-download" @click="handleDonwloadLog">取得</el-button>
@@ -48,7 +48,7 @@
           <span>
             {{filename}}
             <a id="download">
-              <el-button v-if="filename" icon="el-icon-download" size="mini"></el-button>
+              <el-button v-if="filename && exists" icon="el-icon-download" size="mini"></el-button>
             </a>
           </span>
         </el-form-item>
@@ -87,6 +87,7 @@
         dialogVisible: true,
         error: null,
         filename: '',
+        exists: false,
         conditionNote: '',
         events: [],
         form: {
@@ -150,16 +151,23 @@
           }
           let content = (await api.resource.admin.getContainerLogByName(params)).data
 
-          if (!this.form.node) {
-            // ノードが振り分けられていない場合
-            this.filename = this.form.tenant + '_' + this.form.name + '.log'
+          if (content !== '') {
+            this.exists = true
+            if (!this.form.node) {
+              // ノードが振り分けられていない場合
+              this.filename = this.form.tenant + '_' + this.form.name + '.log'
+            } else {
+              this.filename = this.form.node + '_' + this.form.tenant + '_' + this.form.name + '.log'
+            }
+
+            let a = document.getElementById('download')
+            a.download = this.filename
+            a.href = 'data:application/octet-stream,' + encodeURIComponent(content)
           } else {
-            this.filename = this.form.node + '_' + this.form.tenant + '_' + this.form.name + '.log'
+            this.exists = false
+            this.filename = '取得可能なログファイルはありません。'
           }
 
-          let a = document.getElementById('download')
-          a.download = this.filename
-          a.href = 'data:application/octet-stream,' + encodeURIComponent(content)
           this.error = null
         } catch (e) {
           this.error = e


### PR DESCRIPTION
リソース管理画面の以下の表示を修正しました。
- ノードが振り分けられていないときのログのファイル名
- CPUとメモリの合計値の計算方法

ご確認をお願いします。