### PR TITLE
推論管理の[マウントする学習]を選択時の動作を修正

### DIFF
--- a/web-pages/src/components/inference/Create.vue
+++ b/web-pages/src/components/inference/Create.vue
@@ -14,7 +14,7 @@
                 <el-input v-model="name"/>
               </el-form-item>
               <el-form-item label="マウントする学習" prop="parent">
-                <pl-training-completed-history-selector v-model="parent" @input="loadParentInfo"/>
+                <pl-training-completed-history-selector v-model="parent"/>
               </el-form-item>
               <el-form-item label="データセット" prop="dataSet">
                 <pl-dataset-selector v-model="dataSet"/>
@@ -99,7 +99,7 @@
                     <el-input v-model="name"/>
                   </el-form-item>
                   <el-form-item label="マウントする学習" prop="parent">
-                    <pl-training-completed-history-selector v-model="parent" @input="loadParentInfo"/>
+                    <pl-training-completed-history-selector v-model="parent"/>
                   </el-form-item>
                 </el-col>
                 <el-col :span="12">


### PR DESCRIPTION
推論管理の[マウントする学習]を選択時の動作を修正しました。
修正内容としては、
学習管理の親学習選択時の動作と同様、選択した学習の内容を反映しないようにしました。

#67 に関連した修正です。ご確認をお願いします。
