### PR TITLE
CLIの学習のdownload-filesコマンドを修正

### DIFF
--- a/cli/kamonohashi/cli/training.py
+++ b/cli/kamonohashi/cli/training.py
@@ -154,7 +154,7 @@ def list_files(id):
 
 @training.command('download-files')
 @click.argument('id', type=int)
-@click.option('-f', '--file-id', type=int, multiple=True, help='A file id you want to download [multiple]')
+@click.option('-f', '--file-id', type=int, multiple=True, help='A file id you want to download  [multiple]')
 @click.option('-d', '--destination', type=click.Path(exists=True, file_okay=False), required=True,
               help='A path to the output files')
 def download_files(id, file_id, destination):
@@ -163,11 +163,7 @@ def download_files(id, file_id, destination):
     result = api.list_training_files(id, with_url=True)
     pool_manager = api.api_client.rest_client.pool_manager
     for x in result:
-        if file_id is not None and len(file_id) > 0:
-            for fid in file_id:
-                if x.file_id == fid:
-                    object_storage.download_file(pool_manager, x.url, destination, x.file_name)
-        else:
+        if not file_id or x.file_id in file_id:
             object_storage.download_file(pool_manager, x.url, destination, x.file_name)
 
 

--- a/cli/kamonohashi/cli/training.py
+++ b/cli/kamonohashi/cli/training.py
@@ -154,15 +154,21 @@ def list_files(id):
 
 @training.command('download-files')
 @click.argument('id', type=int)
+@click.option('-f', '--file-id', type=int, multiple=True, help='A file id you want to download [multiple]')
 @click.option('-d', '--destination', type=click.Path(exists=True, file_okay=False), required=True,
               help='A path to the output files')
-def download_files(id, destination):
+def download_files(id, file_id, destination):
     """Download files of training"""
     api = rest.TrainingApi(configuration.get_api_client())
     result = api.list_training_files(id, with_url=True)
     pool_manager = api.api_client.rest_client.pool_manager
     for x in result:
-        object_storage.download_file(pool_manager, x.url, destination, x.file_name)
+        if file_id is not None and len(file_id) > 0:
+            for fid in file_id:
+                if x.file_id == fid:
+                    object_storage.download_file(pool_manager, x.url, destination, x.file_name)
+        else:
+            object_storage.download_file(pool_manager, x.url, destination, x.file_name)
 
 
 @training.command('download-container-files')

--- a/web-api/platypus/platypus/ApiModels/TrainingApiModels/AttachedFileOutputModel.cs
+++ b/web-api/platypus/platypus/ApiModels/TrainingApiModels/AttachedFileOutputModel.cs
@@ -1,9 +1,4 @@
-﻿using Nssol.Platypus.Models.TenantModels;
-using Nssol.Platypus.Infrastructure;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
 
 namespace Nssol.Platypus.ApiModels.TrainingApiModels
 {
@@ -17,7 +12,7 @@ namespace Nssol.Platypus.ApiModels.TrainingApiModels
         {
             this.Id = id;
             this.FileName = fileName;
-            this.FileId = fileId;
+            this.FileId = GetFileId(fileId, fileName);
         }
 
         /// <summary>
@@ -41,5 +36,35 @@ namespace Nssol.Platypus.ApiModels.TrainingApiModels
         /// 削除可能か
         /// </summary>
         public bool IsLocked { get; set; }
+
+        /// <summary>
+        /// ファイルIDを取得する
+        /// </summary>
+        /// <param name="fileId">ファイルID</param>
+        /// <param name="fileName">ファイル名</param>
+        private long GetFileId(long fileId, string fileName)
+        {
+            // ファイルIDが負の場合、ファイル名によってIDを設定する。
+            if (fileId < 0)
+            {
+                // ジョブ結果ファイル
+                if (Regex.IsMatch(fileName, @"(training|inference)_output_\d+.zip"))
+                {
+                    return -1;
+                }
+                // ジョブ結果ログファイル
+                else if (Regex.IsMatch(fileName, @"(training|inference)_stdout_stderr_\d+.log"))
+                {
+                    return -2;
+                }
+                // それ以外のファイル
+                else
+                {
+                    return -99;
+                }
+            }
+            // ファイルIDが正の場合、そのまま
+            return fileId;
+        }
     }
 }

--- a/web-api/platypus/platypus/ApiModels/TrainingApiModels/AttachedFileOutputModel.cs
+++ b/web-api/platypus/platypus/ApiModels/TrainingApiModels/AttachedFileOutputModel.cs
@@ -63,7 +63,7 @@ namespace Nssol.Platypus.ApiModels.TrainingApiModels
                     return -99;
                 }
             }
-            // ファイルIDが正の場合、そのまま
+            // ファイルIDが負以外の場合、そのまま
             return fileId;
         }
     }


### PR DESCRIPTION
#105 の要望に応え、より汎用的な仕様になるよう
学習のdownload-filesコマンドを修正しました。
- オプションとして、ファイルIDを追加（複数指定可能）
指定なしの場合、すべてのファイルをダウンロードする

ご確認をお願いします。