### PR TITLE
ユーザ名の前後の空白は除く処理を追加

### DIFF
--- a/web-api/platypus/platypus/Controllers/spa/AccountController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/AccountController.cs
@@ -178,6 +178,9 @@ namespace Nssol.Platypus.Controllers.spa
                 return JsonBadRequest("Invalid inputs.");
             }
 
+            // ユーザ名の前後の空白は除去
+            model.UserName = model.UserName.Trim();
+
             //ユーザ情報からクレームを取得
             Result<List<Claim>, string> signInResult = await loginLogic.SignInAsync(model.UserName, model.Password, model.TenantId);
             if (!signInResult.IsSuccess)

--- a/web-api/platypus/platypus/Controllers/spa/UserController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/UserController.cs
@@ -112,6 +112,10 @@ namespace Nssol.Platypus.Controllers.spa
                 //パスワードに空文字は許可しない
                 return JsonBadRequest($"Password is NOT allowed to set empty string.");
             }
+
+            // 名前の前後の空白は除去
+            model.Name = model.Name.Trim();
+
             //データの存在チェック
             User user = userRepository.GetUser(model.Name);
             if (user != null)


### PR DESCRIPTION
#153 に関して、対応いたしました。
apiでユーザ名の前後の空白文字を除去する処理を追加しました。

ご確認をお願いします。