### PR TITLE
学習・推論の一覧の実行コマンド列のスタイルを修正

### DIFF
--- a/web-pages/src/components/inference/Index.vue
+++ b/web-pages/src/components/inference/Index.vue
@@ -36,7 +36,7 @@
         <el-table-column prop="createdAt" label="開始日時" width="100px"/>
         <el-table-column prop="parentName" label="マウントした学習" width="200px"/>
         <el-table-column prop="dataSet.name" label="データセット" width="120px"/>
-        <el-table-column prop="entryPoint" label="実行コマンド" width="auto"/>
+        <el-table-column prop="entryPoint" label="実行コマンド" width="auto" class-name="entry-point-column"/>
         <el-table-column prop="memo" label="メモ" width="auto"/>
         <el-table-column prop="outputValue" label="出力値" width="200px" sortable/>
         <el-table-column width="30px">
@@ -195,5 +195,17 @@
   .favorite {
     color: rgb(230, 162, 60);
   }
+</style>
 
+<style lang="scss">
+  .entry-point-column {
+    display: table-cell;
+  }
+
+  .entry-point-column div.cell {
+    overflow: hidden;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+  }
 </style>

--- a/web-pages/src/components/training/Index.vue
+++ b/web-pages/src/components/training/Index.vue
@@ -34,7 +34,7 @@
         <el-table-column prop="name" label="学習名" width="120px"/>
         <el-table-column prop="createdAt" label="開始日時" width="200px"/>
         <el-table-column prop="dataSet.name" label="データセット" width="120px"/>
-        <el-table-column prop="entryPoint" label="実行コマンド" width="auto"/>
+        <el-table-column prop="entryPoint" label="実行コマンド" width="auto" class-name="entry-point-column"/>
         <el-table-column prop="memo" label="メモ" width="auto"/>
         <el-table-column width="25px">
           <div slot-scope="scope">
@@ -189,5 +189,17 @@
   .favorite {
     color: rgb(230, 162, 60);
   }
+</style>
 
+<style lang="scss">
+  .entry-point-column {
+    display: table-cell;
+  }
+
+  .entry-point-column div.cell {
+    overflow: hidden;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+  }
 </style>


### PR DESCRIPTION
#130 に関して、対応が完了いたしました。
学習管理・推論管理の一覧画面にて、実行コマンド列のスタイルを修正しました。
- コマンドが長い場合、表示領域が縦に長くなるので、3行まで表示

ご確認をお願いします。