### PR TITLE
データのタグの省略表示対応

### DIFF
--- a/web-pages/src/components/data/Index.vue
+++ b/web-pages/src/components/data/Index.vue
@@ -199,4 +199,11 @@
     text-align: left;
     width: 120px;
   }
+
+  .el-tag--mini {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 </style>

--- a/web-pages/src/components/data/TagEditor.vue
+++ b/web-pages/src/components/data/TagEditor.vue
@@ -10,7 +10,7 @@
       closable
       :disable-transitions="false"
       @close="removeTag(tag)">
-      {{tag}}
+      <span class="tag-ellipsis">{{tag}}</span>
     </el-tag>
     <el-select
       filterable
@@ -99,5 +99,19 @@
     width: 90px;
     margin-left: 10px;
     vertical-align: bottom;
+  }
+
+  .tag-ellipsis {
+    max-width: 98%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+    padding-right: initial;
+  }
+
+  .el-tag {
+    max-width: 100%;
+    display: -webkit-inline-box;
   }
 </style>

--- a/web-pages/src/components/dataset/DatasetTransfer/DataList.vue
+++ b/web-pages/src/components/dataset/DatasetTransfer/DataList.vue
@@ -48,7 +48,7 @@
             </el-col>
 
             <el-col :span="dataSpanSize">{{data.createdAt}}</el-col>
-            <el-col :span="tagSpanSize">
+            <el-col :span="tagSpanSize" style="line-height: normal;">
               <el-tag v-for="(tag, i) in data.tags" :key="i" size="mini" style="margin-right:3px;">
                 {{tag}}
               </el-tag>
@@ -75,9 +75,11 @@
                   <pl-display-text label="メモ" :value="data.memo"/>
                   <el-form-item label="タグ">
                     <br clear="all"/>
-                    <el-tag v-for="(tag, i) in data.tags" :key="i" size="mini" style="margin-right:3px;">
-                      {{tag}}
-                    </el-tag>
+                    <span style="display: block; line-height: normal;">
+                      <el-tag v-for="(tag, i) in data.tags" :key="i" size="mini" style="margin-right:3px;">
+                        {{tag}}
+                      </el-tag>
+                    </span>
                   </el-form-item>
                 </div>
                 <i class="el-icon-info" slot="reference"/>
@@ -294,6 +296,13 @@
     border-radius: 2px 2px 2px 2px;
     margin-top: 8px;
     line-height: 30px;
+  }
+
+  .el-tag--mini {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .color-0 {


### PR DESCRIPTION
#131 に関して、対応が完了いたしました。
データ管理で長い文字列のタグを設定した場合レイアウト崩れが発生するため、省略表示するように修正いたしました。

ご確認をお願いします。