### PR TITLE
データセットのダウンロード処理の修正（ダウンロードURL取得を並列化）

### DIFF
--- a/web-api/platypus/platypus/DataAccess/Repositories/Interfaces/TenantRepositories/IDataSetRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/Interfaces/TenantRepositories/IDataSetRepository.cs
@@ -27,6 +27,13 @@ namespace Nssol.Platypus.DataAccess.Repositories.Interfaces.TenantRepositories
         Task<DataSet> GetDataSetIncludeDataSetEntryAsync(long id);
 
         /// <summary>
+        /// 指定したデータセットIDのデータセット（データセットエントリからデータファイルの外部参照までを含む）を取得します。
+        /// </summary>
+        /// <param name="id">データセットID</param>
+        /// <returns>データセットエンティティ</returns>
+        Task<DataSet> GetDataSetIncludeDataSetEntryAndDataAsync(long id);
+
+        /// <summary>
         /// 指定したデータセットのエントリを全て削除する。
         /// </summary>
         void DeleteAllEntries(long dataSetId);

--- a/web-api/platypus/platypus/DataAccess/Repositories/TenantRepositories/DataSetRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/TenantRepositories/DataSetRepository.cs
@@ -53,6 +53,20 @@ namespace Nssol.Platypus.DataAccess.Repositories.TenantRepositories
         }
 
         /// <summary>
+        /// 指定したデータセットIDのデータセット（データセットエントリからデータファイルの外部参照までを含む）を取得します。
+        /// </summary>
+        /// <param name="id">データセットID</param>
+        /// <returns>
+        /// データセットエンティティ
+        /// </returns>
+        public async Task<DataSet> GetDataSetIncludeDataSetEntryAndDataAsync(long id)
+        {
+            return await GetAll().Include(d => d.DataSetEntries).ThenInclude(d => d.Data)
+                .ThenInclude(d => d.DataProperties).ThenInclude(d => d.DataFile)
+                .SingleOrDefaultAsync(x => x.Id == id);
+        }
+
+        /// <summary>
         /// 指定したデータセットのエントリを全て削除する。
         /// </summary>
         public void DeleteAllEntries(long dataSetId)

--- a/web-api/platypus/platypus/Logic/DataLogic.cs
+++ b/web-api/platypus/platypus/Logic/DataLogic.cs
@@ -2,6 +2,7 @@
 using Nssol.Platypus.Infrastructure;
 using Nssol.Platypus.Logic.Interfaces;
 using Nssol.Platypus.ApiModels.DataApiModels;
+using Nssol.Platypus.Models.TenantModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,6 +53,27 @@ namespace Nssol.Platypus.Logic
             return result;
         }
 
+        /// <summary>
+        /// 指定したIDの全ファイル情報を取得する。
+        /// </summary>
+        /// <param name="data">データ</param>
+        /// <param name="withUrl">結果にダウンロード用のURLを含めるか</param>
+        public IEnumerable<DataFileOutputModel> GetDataFiles(Data data, bool withUrl)
+        {
+            var result = new List<DataFileOutputModel>();
+            
+            foreach (var property in data.DataProperties)
+            {
+                var model = new DataFileOutputModel { Id = data.Id, Key = property.Key, FileId = property.Id, FileName = property.DataFile.FileName };
+
+                if (withUrl)
+                {
+                    model.Url = storageLogic.GetPreSignedUriForGet(ResourceType.Data, property.DataFile.StoredPath, property.DataFile.FileName, true).ToString();
+                }
+                result.Add(model);
+            }
+            return result;
+        }
 
         /// <summary>
         /// 指定されたIDのデータを削除する。

--- a/web-api/platypus/platypus/Logic/Interfaces/IDataLogic.cs
+++ b/web-api/platypus/platypus/Logic/Interfaces/IDataLogic.cs
@@ -1,4 +1,5 @@
 ﻿using Nssol.Platypus.ApiModels.DataApiModels;
+using Nssol.Platypus.Models.TenantModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,6 +19,13 @@ namespace Nssol.Platypus.Logic.Interfaces
         /// <param name="dataId">データID</param>
         /// <param name="withUrl">結果にダウンロード用のURLを含めるか</param>
         IEnumerable<DataFileOutputModel> GetDataFiles(long dataId, bool withUrl);
+
+        /// <summary>
+        /// 指定したIDの全ファイル情報を取得する。
+        /// </summary>
+        /// <param name="data">データ</param>
+        /// <param name="withUrl">結果にダウンロード用のURLを含めるか</param>
+        IEnumerable<DataFileOutputModel> GetDataFiles(Data data, bool withUrl);
 
         /// <summary>
         /// 指定されたIDのデータを削除する。


### PR DESCRIPTION
#146 に関して、修正対応が完了いたしました。
DataSetController.GetDataFiles内のdataLogic.GetDataFilesの処理に時間がかかっているため、Time Outが発生していました。
そのため、ダウンロード取得を並列処理する修正を行いました。

ご確認をお願いします。