### PR TITLE
[-webkit-box-orient]がビルド時に除かれないように修正

### DIFF
--- a/web-pages/src/components/inference/Index.vue
+++ b/web-pages/src/components/inference/Index.vue
@@ -203,6 +203,7 @@
   }
 
   .entry-point-column div.cell {
+    /*! autoprefixer: off */
     overflow: hidden;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;

--- a/web-pages/src/components/training/Index.vue
+++ b/web-pages/src/components/training/Index.vue
@@ -197,6 +197,7 @@
   }
 
   .entry-point-column div.cell {
+    /*! autoprefixer: off */
     overflow: hidden;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;


### PR DESCRIPTION
#130 について、追加で対応が完了いたしました。
以下のスタイルがビルド時に削除されてしまい、行数指定が正しく動作しなかったため、修正しました。
```
-webkit-box-orient: vertical;
```

ご確認をお願いします。
確認項目としては、ビルドした際に生成されるcssファイルに
該当のスタイルが記載されているかを確認ください。

メモ）
ビルドは以下のコマンドを実行してください。
```
npm run build
```