### PR TITLE
ジョブ実行時にデータのメタ情報を取得するように修正

### DIFF
--- a/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/common_scripts.yaml
+++ b/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/common_scripts.yaml
@@ -54,6 +54,7 @@ data:
   prepare-dataset: |
     echo "------------------------- [KAMONOHASHI Prepare] deploy dataset $DATASET_ID into /kqi/input . -------------------------"
     kqi dataset download-files -d /kqi/input $DATASET_ID
+    kqi dataset get -d /kqi/input/meta.json $DATASET_ID
   notify-finish:
     echo $1 > /kqi/tmp/result_exit_code
   wait-ready: |

--- a/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/preproc_scripts.yaml
+++ b/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/preproc_scripts.yaml
@@ -12,6 +12,7 @@ data:
     echo "------------------------- [KAMONOHASHI Main] deploy data into /kqi/input/$DATA_ID . -------------------------"
     mkdir -p /kqi/input/$DATA_ID
     kqi data download-files -d /kqi/input/$DATA_ID $DATA_ID
+    kqi data get -d /kqi/input/meta.json $DATA_ID
   main: |
     bash /kqi/scripts/common/wait-ready
     cd /kqi/git


### PR DESCRIPTION
#48 に関して対応いたしました。
前処理、学習、推論実行時にデータのメタ情報(jsonファイル)を取得するように修正いたしました。

それに伴い、データ管理の以下のCLIコマンドを修正しました。
Optionsに'-d'を追加しました。'dataset get'と使用方法は同様です。
```
kqi data get (ID) [Options]
```

ご確認をお願いします。