### PR TITLE
ノード登録画面のアクセスレベルのデフォルト値設定

### DIFF
--- a/web-pages/src/components/system-setting/node/Create.vue
+++ b/web-pages/src/components/system-setting/node/Create.vue
@@ -59,7 +59,7 @@
         name: undefined,
         memo: undefined,
         partition: undefined,
-        accessLevel: undefined,
+        accessLevel: 2,
         selectedTenants: [], // Selected tenants which can access this node.
         tenants: [], // Tenants to display on a transfer component.
         titles: ['アクセス拒否', 'アクセス許可'], // The title of the transfer component.


### PR DESCRIPTION
#174 に関して対応いたしました。

ノード登録画面の表示時に、デフォルトとして'Public'が設定されるように修正しました。

ご確認をお願いします。