### PR TITLE
GitLab.comを使用できるようにサービス追加と修正

### DIFF
--- a/web-api/platypus/platypus/Infrastructure/Types/GitServiceType.cs
+++ b/web-api/platypus/platypus/Infrastructure/Types/GitServiceType.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Nssol.Platypus.Infrastructure.Types
+﻿namespace Nssol.Platypus.Infrastructure.Types
 {
+    /// <summary>
+    /// Git種別
+    /// </summary>
     public enum GitServiceType
     {
         None = 0,
         GitHub = 1,
         GitLab = 2,
+        GitLabCom = 3
     }
 }

--- a/web-api/platypus/platypus/Logic/GitLogic.cs
+++ b/web-api/platypus/platypus/Logic/GitLogic.cs
@@ -9,7 +9,6 @@ using Nssol.Platypus.Services;
 using Nssol.Platypus.Services.Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Nssol.Platypus.Logic
@@ -214,6 +213,10 @@ namespace Nssol.Platypus.Logic
                 else if (git.ServiceType == GitServiceType.GitHub)
                 {
                     return CommonDiLogic.DynamicDi<GitHubService>();
+                }
+                else if (git.ServiceType == GitServiceType.GitLabCom)
+                {
+                    return CommonDiLogic.DynamicDi<GitLabComService>();
                 }
             }
             return null;

--- a/web-api/platypus/platypus/Services/GitLabComService.cs
+++ b/web-api/platypus/platypus/Services/GitLabComService.cs
@@ -1,0 +1,75 @@
+﻿using Newtonsoft.Json;
+using Nssol.Platypus.Infrastructure;
+using Nssol.Platypus.Models;
+using Nssol.Platypus.ServiceModels.Git;
+using Nssol.Platypus.ServiceModels.Git.GitLabModels;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nssol.Platypus.Services
+{
+    /// <summary>
+    /// GitLab.com用のAPIを呼び出すサービス
+    /// </summary>
+    public class GitLabComService : GitLabService
+    {
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public GitLabComService(
+            Logic.Interfaces.ICommonDiLogic commonDiLogic) : base(commonDiLogic)
+        {
+        }
+        
+        /// <summary>
+        /// リポジトリ一覧を取得する。
+        /// </summary>
+        /// <returns>リポジトリ一覧</returns>
+        public async override Task<Result<IEnumerable<RepositoryModel>, string>> GetAllRepositoriesAsync(UserTenantGitMap gitMap)
+        {
+            await Task.CompletedTask;
+
+            // GitLab.comはトークンに関係なく、Publicリポジトリ(10,000件を超える)も取得するので一覧は取得しない
+            // ユーザに手入力で設定させるため空のリストを返す
+            return Result<IEnumerable<RepositoryModel>, string>.CreateResult(new List<RepositoryModel>());
+        }
+
+        /// <summary>
+        /// オーナー名＆リポジトリ名から、プロジェクトIDを取得する。
+        /// </summary>
+        /// <remarks>
+        /// GitLab APIではGitで一般的な{オーナー名}/{リポジトリ名}ではなく、プロジェクトIDという独自識別子でリポジトリを特定する。
+        /// なので、この変換を行うためのAPI呼び出しが必要。
+        /// ちなみに、逆にWebUIを参照する際はオーナー名が必要という仕様。
+        /// </remarks>
+        protected async override Task<Result<string, string>> GetProjectIdAsync(UserTenantGitMap gitMap, string repositoryName, string owner)
+        {
+            // オーナー名＆リポジトリ名を指定して取得する
+            RequestParam param = CreateRequestParam(gitMap);
+            param.ApiPath = $"/api/v4/projects/{owner}%2F{repositoryName}";
+
+            var response = await SendGetRequestAsync(param);
+
+            if (response.IsSuccess)
+            {
+                //一度GitLabの専用出力モデルに吐き出す
+                var result = JsonConvert.DeserializeObject<IEnumerable<GetRepositoryModel>>("[" + response.Value + "]");
+                //ロジック層に返すための版用モデルに変換
+                var outModel = result.First();
+                if (outModel == null)
+                {
+                    string message = $"Repository {owner}/{repositoryName} is not found.";
+                    LogWarning(message);
+                    return Result<string, string>.CreateErrorResult(message);
+                }
+                return Result<string, string>.CreateResult(outModel.id.ToString());
+            }
+            else
+            {
+                LogError(response.Error);
+                return Result<string, string>.CreateErrorResult(response.Error);
+            }
+        }
+    }
+}

--- a/web-api/platypus/platypus/Services/GitLabService.cs
+++ b/web-api/platypus/platypus/Services/GitLabService.cs
@@ -1,16 +1,14 @@
-﻿using Nssol.Platypus.Services.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Newtonsoft.Json;
 using Nssol.Platypus.Infrastructure;
 using Nssol.Platypus.Models;
 using Nssol.Platypus.ServiceModels.Git;
-using System.Net.Http;
-using Microsoft.AspNetCore.WebUtilities;
-using Newtonsoft.Json;
 using Nssol.Platypus.ServiceModels.Git.GitLabModels;
-using System.Text.RegularExpressions;
+using Nssol.Platypus.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Nssol.Platypus.Services
 {
@@ -29,7 +27,7 @@ namespace Nssol.Platypus.Services
         /// 特に範囲は限定せず、<see cref="Git.Token"/>の権限で参照可能なすべてのリポジトリが対象となる。
         /// </summary>
         /// <returns>リポジトリ一覧</returns>
-        public async Task<Result<IEnumerable<RepositoryModel>, string>> GetAllRepositoriesAsync(UserTenantGitMap gitMap)
+        public async virtual Task<Result<IEnumerable<RepositoryModel>, string>> GetAllRepositoriesAsync(UserTenantGitMap gitMap)
         {
             var response = await SendGetFullPageRequestsAsync<GetRepositoryModel>("/api/v4/projects", gitMap, new Dictionary<string, string>());
             
@@ -59,7 +57,7 @@ namespace Nssol.Platypus.Services
         /// なので、この変換を行うためのAPI呼び出しが必要。
         /// ちなみに、逆にWebUIを参照する際はオーナー名が必要という仕様。
         /// </remarks>
-        private async Task<Result<string, string>> GetProjectIdAsync(UserTenantGitMap gitMap, string repositoryName, string owner)
+        protected async virtual Task<Result<string, string>> GetProjectIdAsync(UserTenantGitMap gitMap, string repositoryName, string owner)
         {
             //検索上限が100件だが、リポジトリ名でフィルタ（部分一致）をかけて検索するので、そこまでの件数にはならない想定
             RequestParam param = CreateRequestParam(gitMap);
@@ -276,7 +274,7 @@ namespace Nssol.Platypus.Services
         /// <summary>
         /// 共通で使うパラメータを生成
         /// </summary>
-        private RequestParam CreateRequestParam(UserTenantGitMap gitMap)
+        protected RequestParam CreateRequestParam(UserTenantGitMap gitMap)
         {
             return new RequestParam()
             {

--- a/web-api/platypus/platypus/Startup.cs
+++ b/web-api/platypus/platypus/Startup.cs
@@ -111,6 +111,7 @@ namespace Nssol.Platypus
             // 切替のため型指定でDI設定
             services.AddTransient<GitHubService>();
             services.AddTransient<GitLabService>();
+            services.AddTransient<GitLabComService>();
             services.AddTransient<DockerHubRegistryService>();
             services.AddTransient<GitLabRegistryService>();
             services.AddTransient<PrivateDockerRegistryService>();

--- a/web-pages/src/components/system-setting/git/Index.vue
+++ b/web-pages/src/components/system-setting/git/Index.vue
@@ -10,13 +10,10 @@
       <el-table class="git-table pl-index-table" :data="tableData" @row-click="openEditDialog" border>
         <el-table-column prop="id" label="ID" width="100px"/>
         <el-table-column prop="name" label="リポジトリ名" width="auto"/>
-        <el-table-column prop="repositoryUrl" label="リポジトリURL" width="auto">
-        </el-table-column>
+        <el-table-column prop="repositoryUrl" label="リポジトリURL" width="auto"/>
         <el-table-column prop="serviceType" label="種別" width="auto">
           <template slot-scope="scope">
-            <span v-if="scope.row.serviceType===1">GitHub</span>
-            <span v-else-if="scope.row.serviceType===2">GitLab</span>
-            <span v-else>{{ serviceType }}</span>
+            {{ displayNameOfServiceType(scope.row.serviceType) }}
           </template>
         </el-table-column>
         <el-table-column prop="apiUrl" label="API URL" width="auto">
@@ -44,8 +41,15 @@
     },
     methods: {
       async retrieveData () {
+        // serviceTypeIdと表示名の一覧取得
+        this.serviceTypes = (await api.git.admin.getTypes()).data
         let response = await api.git.admin.getEndpoints()
         this.tableData = response.data
+      },
+      // ServiceTypeの数値から表示名に変換
+      displayNameOfServiceType (serviceTypeId) {
+        let serviceType = this.serviceTypes.find(s => s.id === serviceTypeId)
+        return serviceType.name
       },
       openCreateDialog () {
         this.$router.push('git/create')


### PR DESCRIPTION
#191 に関して対応が完了いたしました。

GitLab.comを登録、使用できるように専用サービスクラスを追加しました。
学習実行画面等のGitのリポジトリについては、一覧の取得は行わずにユーザ自身に手入力させる想定です。

また、
Gitの一覧画面についてですが、
種別を汎用的に取得表示するために修正しております。（レジストリの一覧と同様の処理にしました。）
合わせてご確認をお願いします。
