### PR TITLE
GitとRegistryの登録・編集画面のUI変更

### DIFF
--- a/web-pages/src/components/system-setting/git/Create.vue
+++ b/web-pages/src/components/system-setting/git/Create.vue
@@ -9,16 +9,17 @@
       <el-form-item label="名前" prop="name">
         <el-input v-model="name"/>
       </el-form-item>
-      <el-form-item label="リポジトリURL" prop="repositoryUrl">
-        <el-input v-model="repositoryUrl"/>
-      </el-form-item>
       <el-form-item label="Git種別" prop="serviceType">
         <el-select v-model="serviceType" style="width: 100%">
           <el-option v-for="(t, idx) in types" :key="idx" :label="t.name" :value="t.id"/>
         </el-select>
       </el-form-item>
+      <el-form-item label="リポジトリURL" prop="repositoryUrl">
+        <el-input v-model="repositoryUrl" @change="handleChange"/>
+      </el-form-item>
       <el-form-item label="API URL" prop="apiUrl">
-        <el-input v-model="apiUrl"/>
+        <el-switch v-model="editApiUrl"/>
+        <el-input v-model="apiUrl" :disabled="!editApiUrl"/>
       </el-form-item>
 
       <el-row class="right-button-group footer">
@@ -46,6 +47,7 @@
         repositoryUrl: undefined,
         serviceType: undefined,
         apiUrl: undefined,
+        editApiUrl: false,
         rules: {
           name: [{
             required: true,
@@ -104,6 +106,11 @@
             }
           }
         })
+      },
+      handleChange () {
+        if (!this.editApiUrl) {
+          this.apiUrl = this.repositoryUrl
+        }
       },
       closeDialog (done) {
         done()

--- a/web-pages/src/components/system-setting/git/Edit.vue
+++ b/web-pages/src/components/system-setting/git/Edit.vue
@@ -9,16 +9,18 @@
       <el-form-item label="名前" prop="name">
         <el-input v-model="name" :disabled="isNotEditable"/>
       </el-form-item>
-      <el-form-item label="リポジトリURL" prop="repositoryUrl">
-        <el-input v-model="repositoryUrl" :disabled="isNotEditable"/>
-      </el-form-item>
       <el-form-item label="Git種別" prop="serviceType">
         <el-select v-model="serviceType" style="width: 100%" :disabled="isNotEditable">
           <el-option v-for="(t, idx) in types" :key="idx" :label="t.name" :value="t.id"/>
         </el-select>
       </el-form-item>
+      <el-form-item label="リポジトリURL" prop="repositoryUrl">
+        <el-input v-model="repositoryUrl" :disabled="isNotEditable" @change="handleChange"/>
+      </el-form-item>
       <el-form-item label="API URL" prop="apiUrl">
-        <el-input v-model="apiUrl" :disabled="isNotEditable"/>
+        <el-switch v-model="editApiUrl"
+                   :disabled="isNotEditable"/>
+        <el-input v-model="apiUrl" :disabled="isNotEditable || !editApiUrl"/>
       </el-form-item>
 
       <el-row :gutter="20" class="footer">
@@ -58,6 +60,7 @@
         repositoryUrl: undefined,
         serviceType: undefined,
         apiUrl: undefined,
+        editApiUrl: false,
         isNotEditable: false,
         rules: {
           name: [{
@@ -102,6 +105,7 @@
           this.serviceType = result.serviceType
           this.apiUrl = result.apiUrl
           this.isNotEditable = result.isNotEditable
+          this.editApiUrl = result.repositoryUrl !== result.apiUrl
           this.error = null
         } catch (e) {
           this.error = e
@@ -137,6 +141,11 @@
           this.error = undefined
         } catch (e) {
           this.error = e
+        }
+      },
+      handleChange () {
+        if (!this.editApiUrl) {
+          this.apiUrl = this.repositoryUrl
         }
       },
       closeDialog (done) {

--- a/web-pages/src/components/system-setting/registry/Create.vue
+++ b/web-pages/src/components/system-setting/registry/Create.vue
@@ -64,6 +64,8 @@
   import api from '@/api/v1/api'
   import DisplayError from '@/components/common/DisplayError'
 
+  const defaultProtocol = 'https://'
+
   export default {
     name: 'RegistryCreate',
     components: {
@@ -83,7 +85,6 @@
         serviceTypes: Array, // /api/v1/admin/registry/types の結果
         editApiUrl: false,
         editRegistryUrl: false,
-        defaultProtocol: 'https://',
         rules: {
           name: [{required: true, message: '必須項目です'}],
           host: [{required: true, message: '必須項目です'}],
@@ -129,14 +130,14 @@
       handleChange () {
         if (!this.editApiUrl) {
           if (this.host) {
-            this.apiUrl = this.defaultProtocol + this.host
+            this.apiUrl = defaultProtocol + this.host
           } else {
             this.apiUrl = ''
           }
         }
         if (!this.editRegistryUrl) {
           if (this.host && this.portNo) {
-            this.registryUrl = this.defaultProtocol + this.host + ':' + this.portNo
+            this.registryUrl = defaultProtocol + this.host + ':' + this.portNo
           } else {
             this.registryUrl = ''
           }

--- a/web-pages/src/components/system-setting/registry/Create.vue
+++ b/web-pages/src/components/system-setting/registry/Create.vue
@@ -24,21 +24,24 @@
         <el-row>
           <el-col :span="16">
             <el-form-item label="ホスト名" prop="host">
-              <el-input v-model="host"/>
+              <el-input v-model="host" @change="handleChange"/>
             </el-form-item>
           </el-col>
           <el-col :span="8">
             <el-form-item label="ポート" prop="portNo">
               <el-input-number v-model="portNo" :min="1" :max="65535"
-                               controls-position="right" style="width:100%;"/>
+                               controls-position="right" style="width:100%;"
+                               @change="handleChange"/>
             </el-form-item>
           </el-col>
         </el-row>
         <el-form-item label="API URL" prop="apiUrl">
-          <el-input v-model="apiUrl"/>
+          <el-switch v-model="editApiUrl"/>
+          <el-input v-model="apiUrl" :disabled="!editApiUrl" @change="handleChange"/>
         </el-form-item>
         <el-form-item label="URL" prop="registryUrl">
-          <el-input v-model="registryUrl"/>
+          <el-switch v-model="editRegistryUrl"/>
+          <el-input v-model="registryUrl" :disabled="!editRegistryUrl"/>
         </el-form-item>
         <div v-if="serviceType === 2">
           <el-form-item label="プロジェクト名" prop="projectName">
@@ -78,6 +81,8 @@
         registryUrl: undefined,
         apiUrl: undefined,
         serviceTypes: Array, // /api/v1/admin/registry/types の結果
+        editApiUrl: false,
+        editRegistryUrl: false,
         rules: {
           name: [{required: true, message: '必須項目です'}],
           host: [{required: true, message: '必須項目です'}],
@@ -119,6 +124,22 @@
             }
           }
         )
+      },
+      handleChange () {
+        if (!this.editApiUrl) {
+          if (this.host) {
+            this.apiUrl = 'https://' + this.host
+          } else {
+            this.apiUrl = ''
+          }
+        }
+        if (!this.editRegistryUrl) {
+          if (this.apiUrl && this.portNo) {
+            this.registryUrl = this.apiUrl + ':' + this.portNo
+          } else {
+            this.registryUrl = ''
+          }
+        }
       },
       closeDialog (done) {
         done()

--- a/web-pages/src/components/system-setting/registry/Create.vue
+++ b/web-pages/src/components/system-setting/registry/Create.vue
@@ -83,6 +83,7 @@
         serviceTypes: Array, // /api/v1/admin/registry/types の結果
         editApiUrl: false,
         editRegistryUrl: false,
+        defaultProtocol: 'https://',
         rules: {
           name: [{required: true, message: '必須項目です'}],
           host: [{required: true, message: '必須項目です'}],
@@ -128,14 +129,14 @@
       handleChange () {
         if (!this.editApiUrl) {
           if (this.host) {
-            this.apiUrl = 'https://' + this.host
+            this.apiUrl = this.defaultProtocol + this.host
           } else {
             this.apiUrl = ''
           }
         }
         if (!this.editRegistryUrl) {
-          if (this.apiUrl && this.portNo) {
-            this.registryUrl = this.apiUrl + ':' + this.portNo
+          if (this.host && this.portNo) {
+            this.registryUrl = this.defaultProtocol + this.host + ':' + this.portNo
           } else {
             this.registryUrl = ''
           }

--- a/web-pages/src/components/system-setting/registry/Edit.vue
+++ b/web-pages/src/components/system-setting/registry/Edit.vue
@@ -96,6 +96,7 @@
         serviceTypes: Array, // /api/v1/admin/registry/types の結果
         editApiUrl: false,
         editRegistryUrl: false,
+        defaultProtocol: 'https://',
         isNotEditable: false,
         rules: {
           name: [{required: true, message: '必須項目です'}],
@@ -150,8 +151,8 @@
         this.projectName = result.projectName
         this.serviceType = result.serviceType
         this.isNotEditable = result.isNotEditable
-        this.editApiUrl = 'https://' + result.host !== result.apiUrl
-        this.editRegistryUrl = result.apiUrl + ':' + result.portNo !== result.registryUrl
+        this.editApiUrl = this.defaultProtocol + result.host !== result.apiUrl
+        this.editRegistryUrl = this.defaultProtocol + result.host + ':' + result.portNo !== result.registryUrl
       },
       async deleteRegistry () {
         try {
@@ -164,14 +165,14 @@
       handleChange () {
         if (!this.editApiUrl) {
           if (this.host) {
-            this.apiUrl = 'https://' + this.host
+            this.apiUrl = this.defaultProtocol + this.host
           } else {
             this.apiUrl = ''
           }
         }
         if (!this.editRegistryUrl) {
-          if (this.apiUrl && this.portNo) {
-            this.registryUrl = this.apiUrl + ':' + this.portNo
+          if (this.host && this.portNo) {
+            this.registryUrl = this.defaultProtocol + this.host + ':' + this.portNo
           } else {
             this.registryUrl = ''
           }

--- a/web-pages/src/components/system-setting/registry/Edit.vue
+++ b/web-pages/src/components/system-setting/registry/Edit.vue
@@ -73,6 +73,8 @@
   import DisplayError from '@/components/common/DisplayError'
   import api from '@/api/v1/api'
 
+  const defaultProtocol = 'https://'
+
   export default {
     name: 'RegistryEdit',
     components: {
@@ -96,7 +98,6 @@
         serviceTypes: Array, // /api/v1/admin/registry/types の結果
         editApiUrl: false,
         editRegistryUrl: false,
-        defaultProtocol: 'https://',
         isNotEditable: false,
         rules: {
           name: [{required: true, message: '必須項目です'}],
@@ -151,8 +152,8 @@
         this.projectName = result.projectName
         this.serviceType = result.serviceType
         this.isNotEditable = result.isNotEditable
-        this.editApiUrl = this.defaultProtocol + result.host !== result.apiUrl
-        this.editRegistryUrl = this.defaultProtocol + result.host + ':' + result.portNo !== result.registryUrl
+        this.editApiUrl = defaultProtocol + result.host !== result.apiUrl
+        this.editRegistryUrl = defaultProtocol + result.host + ':' + result.portNo !== result.registryUrl
       },
       async deleteRegistry () {
         try {
@@ -165,14 +166,14 @@
       handleChange () {
         if (!this.editApiUrl) {
           if (this.host) {
-            this.apiUrl = this.defaultProtocol + this.host
+            this.apiUrl = defaultProtocol + this.host
           } else {
             this.apiUrl = ''
           }
         }
         if (!this.editRegistryUrl) {
           if (this.host && this.portNo) {
-            this.registryUrl = this.defaultProtocol + this.host + ':' + this.portNo
+            this.registryUrl = defaultProtocol + this.host + ':' + this.portNo
           } else {
             this.registryUrl = ''
           }

--- a/web-pages/src/components/system-setting/registry/Edit.vue
+++ b/web-pages/src/components/system-setting/registry/Edit.vue
@@ -24,20 +24,26 @@
         <el-row>
           <el-col :span="16">
             <el-form-item label="ホスト名" prop="host">
-              <el-input v-model="host" :disabled="isNotEditable"/>
+              <el-input v-model="host" :disabled="isNotEditable" @change="handleChange"/>
             </el-form-item>
           </el-col>
           <el-col :span="8">
             <el-form-item label="ポート" prop="portNo">
-              <el-input-number v-model="portNo" :min="1" :max="65535" controls-position="right" style="width: 100%;" :disabled="isNotEditable"/>
+              <el-input-number v-model="portNo" :min="1" :max="65535"
+                               controls-position="right" style="width: 100%;"
+                               :disabled="isNotEditable" @change="handleChange"/>
             </el-form-item>
           </el-col>
         </el-row>
         <el-form-item label="API URL" prop="apiUrl">
-          <el-input v-model="apiUrl" :disabled="isNotEditable"/>
+          <el-switch v-model="editApiUrl"
+                     :disabled="isNotEditable"/>
+          <el-input v-model="apiUrl" :disabled="isNotEditable || !editApiUrl" @change="handleChange"/>
         </el-form-item>
         <el-form-item label="URL" prop="registryUrl">
-          <el-input v-model="registryUrl" :disabled="isNotEditable"/>
+          <el-switch v-model="editRegistryUrl"
+                     :disabled="isNotEditable"/>
+          <el-input v-model="registryUrl" :disabled="isNotEditable || !editRegistryUrl"/>
         </el-form-item>
         <div v-if="serviceType === 2">
           <el-form-item label="プロジェクト名" prop="projectName">
@@ -88,6 +94,8 @@
         registryUrl: undefined,
         apiUrl: undefined,
         serviceTypes: Array, // /api/v1/admin/registry/types の結果
+        editApiUrl: false,
+        editRegistryUrl: false,
         isNotEditable: false,
         rules: {
           name: [{required: true, message: '必須項目です'}],
@@ -142,6 +150,8 @@
         this.projectName = result.projectName
         this.serviceType = result.serviceType
         this.isNotEditable = result.isNotEditable
+        this.editApiUrl = 'https://' + result.host !== result.apiUrl
+        this.editRegistryUrl = result.apiUrl + ':' + result.portNo !== result.registryUrl
       },
       async deleteRegistry () {
         try {
@@ -149,6 +159,22 @@
           this.emitDone()
         } catch (e) {
           this.error = e
+        }
+      },
+      handleChange () {
+        if (!this.editApiUrl) {
+          if (this.host) {
+            this.apiUrl = 'https://' + this.host
+          } else {
+            this.apiUrl = ''
+          }
+        }
+        if (!this.editRegistryUrl) {
+          if (this.apiUrl && this.portNo) {
+            this.registryUrl = this.apiUrl + ':' + this.portNo
+          } else {
+            this.registryUrl = ''
+          }
         }
       },
       emitDone () {


### PR DESCRIPTION
#200 に関して対応が完了いたしました。
Git管理の登録、編集画面のUIとレジストリ管理の登録・編集画面のUIを変更しました。

Git管理について。
 - [API URL]が非アクティブの場合
　 [リポジトリURL]が変更されたら、[API URL]に反映する。
 - [API URL]がアクティブの場合
　[API URL]を任意に変更可能。

レジストリ管理について。
- [API URL]が非アクティブの場合
　[ホスト名]が変更されたら、[API URL]に反映する。
- [API URL]がアクティブの場合
　[API URL]を任意に変更可能。

- [URL]が非アクティブの場合
　[ポート]または[API URL]が変更されたら、[URL]に反映する。
- [URL]がアクティブの場合
　[URL]を任意に変更可能。

ご確認をお願いします。