### PR TITLE
NotebookHistoriesの実行中レコード検索をキャッシュされないように修正

### DIFF
--- a/web-api/platypus/platypus/DataAccess/Repositories/Interfaces/TenantRepositories/INotebookHistoryRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/Interfaces/TenantRepositories/INotebookHistoryRepository.cs
@@ -31,10 +31,10 @@ namespace Nssol.Platypus.DataAccess.Repositories.Interfaces.TenantRepositories
         Task<NotebookHistory> GetIncludeAllAsync(long id);
 
         /// <summary>
-        /// テナント横断で全データ（外部参照を含む）をすべて取得する。
+        /// テナント横断で全データ（外部参照を含む）をすべて取得する。（取得結果はキャッシュされない）
         /// ソートはIDの逆順。
         /// </summary>
-        Task<IEnumerable<NotebookHistory>> GetAllIncludeTenantAsync();
+        Task<IEnumerable<NotebookHistory>> GetAllIncludeTenantAsNoTrackingAsync();
 
         /// <summary>
         /// 検索条件に合致するデータを一件取得する

--- a/web-api/platypus/platypus/DataAccess/Repositories/TenantRepositories/NotebookHistoryRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/TenantRepositories/NotebookHistoryRepository.cs
@@ -55,13 +55,13 @@ namespace Nssol.Platypus.DataAccess.Repositories.TenantRepositories
         }
 
         /// <summary>
-        /// テナント横断で全データ（外部参照を含む）をすべて取得する。
+        /// テナント横断で全データ（外部参照を含む）をすべて取得する。（取得結果はキャッシュされない）
         /// ソートはIDの逆順。
         /// </summary>
-        public async Task<IEnumerable<NotebookHistory>> GetAllIncludeTenantAsync()
+        public async Task<IEnumerable<NotebookHistory>> GetAllIncludeTenantAsNoTrackingAsync()
         {
             return await GetModelAll<NotebookHistory>(true).Include(t => t.Tenant)
-                .OrderByDescending(t => t.Id).ToListAsync();
+                .OrderByDescending(t => t.Id).AsNoTracking().ToListAsync();
         }
 
         /// <summary>

--- a/web-api/platypus/platypus/Logic/HostedService/DeleteNotebookContainerTimer.cs
+++ b/web-api/platypus/platypus/Logic/HostedService/DeleteNotebookContainerTimer.cs
@@ -72,7 +72,7 @@ namespace Nssol.Platypus.Logic.HostedService
             try
             {
                 // テーブル NotebookHistories の'Killed'以外の全レコードを取得
-                var notebookHistories = notebookHistoryRepository.GetAllIncludeTenantAsync().Result.Where(h => h.GetStatus().ToString() != ContainerStatus.Killed.Name);
+                var notebookHistories = notebookHistoryRepository.GetAllIncludeTenantAsNoTrackingAsync().Result.Where(h => h.GetStatus().ToString() != ContainerStatus.Killed.Name);
                 if (notebookHistories.Count() == 0)
                 {
                     // レコードが1件も存在しなければ終了


### PR DESCRIPTION
#216 に関して、対応いたしました。

一回取得した結果がキャッシュされて（残ってしまって）いるため、再度取得しようとしても更新されない。
そのため、キャッシュされないように修正しました。

ご確認をお願いします。