### PR TITLE
実行コマンド失敗時にzip化しないように修正

### DIFF
--- a/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/inference_scripts.yaml
+++ b/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/inference_scripts.yaml
@@ -25,7 +25,7 @@ data:
     bash /kqi/scripts/common/prepare-kqi-conf
     bash /kqi/scripts/common/wait-finish
     
-    if [ $ZIP_FILE_CREATED = "True" ]
+    if [ $ZIP_FILE_CREATED = "True" ] && [ $(cat /kqi/tmp/result_exit_code) -eq 0 ]
     then
         echo "------------------------- [KAMONOHASHI Finish] zip /kqi/output  -------------------------"
         zip -r /kqi/tmp/@Raw(Model.ScriptType)_output_${INFERENCE_ID}.zip /kqi/output && mv /kqi/tmp/@Raw(Model.ScriptType)_output_${INFERENCE_ID}.zip /kqi/attach

--- a/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/training_scripts.yaml
+++ b/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/training_scripts.yaml
@@ -25,7 +25,7 @@ data:
     bash /kqi/scripts/common/prepare-kqi-conf
     bash /kqi/scripts/common/wait-finish
 
-    if [ $ZIP_FILE_CREATED = "True" ]
+    if [ $ZIP_FILE_CREATED = "True" ] && [ $(cat /kqi/tmp/result_exit_code) -eq 0 ]
     then
         echo "------------------------- [KAMONOHASHI Finish] zip /kqi/output  -------------------------"
         zip -r /kqi/tmp/@Raw(Model.ScriptType)_output_${TRAINING_ID}.zip /kqi/output && mv /kqi/tmp/@Raw(Model.ScriptType)_output_${TRAINING_ID}.zip /kqi/attach


### PR DESCRIPTION
もし、zip化に成功した場合、ステータスがcompletedになってしまうため、
実行コマンド失敗時にzip化処理をしないように修正しました。

ご確認をお願いします。