### PR TITLE
学習・推論履歴の結果zip圧縮の表示を変更

### DIFF
--- a/web-pages/src/components/inference/Edit.vue
+++ b/web-pages/src/components/inference/Edit.vue
@@ -143,11 +143,10 @@
                   <el-input v-model="downloadFilesCommand" :readonly="true"/>
             </el-form-item >
             <el-form-item label="結果Zip圧縮">
-              <el-switch v-model="zip"
-                          style="width: 100%;"
-                          inactive-text="圧縮しない"
-                          active-text="圧縮する"
-                          disabled/>
+              <div class="el-input">
+                <span v-if="zip">圧縮する</span>
+                <span v-else>圧縮しない</span>
+              </div>
             </el-form-item>
 
             <el-form-item label="添付ファイル">

--- a/web-pages/src/components/training/Edit.vue
+++ b/web-pages/src/components/training/Edit.vue
@@ -151,11 +151,10 @@
                   <el-input v-model="downloadFilesCommand" :readonly="true"/>
             </el-form-item >
             <el-form-item label="結果Zip圧縮">
-              <el-switch v-model="zip"
-                          style="width: 100%;"
-                          inactive-text="圧縮しない"
-                          active-text="圧縮する"
-                          disabled/>
+              <div class="el-input">
+                <span v-if="zip">圧縮する</span>
+                <span v-else>圧縮しない</span>
+              </div>
             </el-form-item>
             <el-form-item label="添付ファイル">
               <br/>


### PR DESCRIPTION
#235 に関して、対応いたしました。

学習と推論履歴の結果zip圧縮の表示を変更しました。
変更できない仕様のため、文字列に変更しました。

ご確認をお願いします。