### PR TITLE
クラスタサービスにコンテナレジストリを登録失敗しても処理を継続するように修正

### DIFF
--- a/web-api/platypus/platypus/Controllers/spa/UserController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/UserController.cs
@@ -402,11 +402,7 @@ namespace Nssol.Platypus.Controllers.spa
                 foreach (var map in maps)
                 {
                     //レジストリを登録
-                    var registryResult = await clusterManagementLogic.RegistRegistryToTenantAsync(tenant.Name, map);
-                    if (registryResult == false)
-                    {
-                        return JsonError(HttpStatusCode.ServiceUnavailable, "Couldn't map the tenant and the registry in a cluster management service. Please contact a user administrator.");
-                    }
+                    await clusterManagementLogic.RegistRegistryToTenantAsync(tenant.Name, map);
                 }
             }
 


### PR DESCRIPTION
#234 に関して、対応いたしました。

ユーザ情報設定画面でのtoken更新時と同様に、クラスタ管理サービスにコンテナレジストリの登録に失敗しても処理を継続し、更新を確定するように修正しました。

ご確認をお願いします。