### PR TITLE
エラーメッセージの見切れを修正

### DIFF
--- a/web-pages/src/util/axios-ext.js
+++ b/web-pages/src/util/axios-ext.js
@@ -120,9 +120,7 @@ export function axiosErrorHandlingInterceptors ($axios, errorCallback) {
             typeof error.response.data === 'object' &&
             'title' in error.response.data) {
             if (!error.config.apiDisabledError) {
-              let title = error.response.data.title
-              let detail = error.response.data.detail
-              let msg = (detail) ? title + '<br />' + detail : title
+              let msg = error.response.data.title
               vue.$notify.error({title: 'エラーが発生しました', dangerouslyUseHTMLString: true, message: msg})
             } else {
               if (status === 500) { // internal server error


### PR DESCRIPTION
#133 について対応いたしました。

エラーメッセージが見切れることがある原因として、サーバ側の処理で発生したExceptionを長い文字列として画面上に表示していました。
ユーザとしては、システム内部のエラーについて画面に表示されてもFront側からは何もできないので、詳細部('detail')のメッセージは表示しないように修正しました。

ご確認をお願いします。