### PR TITLE
ユーザ・テナント情報更新時にトークン情報が消えないよう修正

### DIFF
--- a/web-api/platypus/platypus/DataAccess/Repositories/GitRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/GitRepository.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Nssol.Platypus.DataAccess.Core;
 using Nssol.Platypus.DataAccess.Repositories.Interfaces;
 using Nssol.Platypus.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -80,10 +81,10 @@ namespace Nssol.Platypus.DataAccess.Repositories
                         UserId = userMap.UserId,
                     };
 
-                    //既に同じGitと紐づいていたら、その認証情報を使いまわす
+                    //認証情報が空欄のものをはじく
                     var existMap = GetModelAll<UserTenantGitMap>().Include(m => m.TenantGitMap)
-                        .Where(m => m.UserId == userMap.UserId && m.TenantGitMap.GitId == git.Id).FirstOrDefault();
-                    if (existMap != null)
+                        .Where(m => m.UserId == userMap.UserId && m.TenantGitMap.GitId == git.Id && !String.IsNullOrEmpty(m.GitToken)).FirstOrDefault();
+                    if (existMap != null && !String.IsNullOrEmpty(existMap.GitToken))
                     {
                         utgMap.GitToken = existMap.GitToken;
                     }

--- a/web-api/platypus/platypus/DataAccess/Repositories/RegistryRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/RegistryRepository.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nssol.Platypus.DataAccess.Repositories.Interfaces;
+using System;
 
 namespace Nssol.Platypus.DataAccess.Repositories
 {
@@ -80,10 +81,10 @@ namespace Nssol.Platypus.DataAccess.Repositories
                         UserId = userMap.UserId,
                     };
 
-                    //既に同じレジストリと紐づいていたら、その認証情報を使いまわす
+                    //認証情報が空欄のものをはじく
                     var existMap = GetModelAll<UserTenantRegistryMap>().Include(m => m.TenantRegistryMap)
-                        .Where(m => m.UserId == userMap.UserId && m.TenantRegistryMap.RegistryId == registry.Id).FirstOrDefault();
-                    if (existMap != null)
+                        .Where(m => m.UserId == userMap.UserId && m.TenantRegistryMap.RegistryId == registry.Id && !String.IsNullOrEmpty(m.RegistryPassword)).FirstOrDefault();
+                    if (existMap != null && !String.IsNullOrEmpty(existMap.RegistryPassword))
                     {
                         utrMap.RegistryUserName = existMap.RegistryUserName;
                         utrMap.RegistryPassword = existMap.RegistryPassword;

--- a/web-api/platypus/platypus/DataAccess/Repositories/UserRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/UserRepository.cs
@@ -308,7 +308,7 @@ namespace Nssol.Platypus.DataAccess.Repositories
                     //認証情報が空欄のものをはじく
                     var existMap = GetModelAll<UserTenantGitMap>().Include(m => m.TenantGitMap)
                         .Where(m => m.UserId == user.Id && m.TenantGitMap.GitId == GitMap.GitId && !String.IsNullOrEmpty(m.GitToken)).FirstOrDefault();
-                    if (!String.IsNullOrEmpty(existMap.GitToken))
+                    if (existMap != null && !String.IsNullOrEmpty(existMap.GitToken))
                     {
                         utrMap.GitToken = existMap.GitToken;
                     }
@@ -337,10 +337,10 @@ namespace Nssol.Platypus.DataAccess.Repositories
                         UserId = user.Id
                     };
 
-                    //既に同じレジストリと紐づいていたら、その認証情報を使いまわす
+                    //認証情報が空欄のものをはじく
                     var existMap = GetModelAll<UserTenantRegistryMap>().Include(m => m.TenantRegistryMap)
-                        .Where(m => m.UserId == user.Id && m.TenantRegistryMap.RegistryId == registryMap.RegistryId).FirstOrDefault();
-                    if (existMap != null)
+                        .Where(m => m.UserId == user.Id && m.TenantRegistryMap.RegistryId == registryMap.RegistryId && !String.IsNullOrEmpty(m.RegistryPassword)).FirstOrDefault();
+                    if (existMap != null && !String.IsNullOrEmpty(existMap.RegistryPassword))
                     {
                         utrMap.RegistryUserName = existMap.RegistryUserName;
                         utrMap.RegistryPassword = existMap.RegistryPassword;

--- a/web-api/platypus/platypus/DataAccess/Repositories/UserRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/UserRepository.cs
@@ -305,10 +305,10 @@ namespace Nssol.Platypus.DataAccess.Repositories
                         UserId = user.Id
                     };
 
-                    //既に同じGitと紐づいていたら、その認証情報を使いまわす
+                    //認証情報が空欄のものをはじく
                     var existMap = GetModelAll<UserTenantGitMap>().Include(m => m.TenantGitMap)
-                        .Where(m => m.UserId == user.Id && m.TenantGitMap.GitId == GitMap.GitId).FirstOrDefault();
-                    if (existMap != null)
+                        .Where(m => m.UserId == user.Id && m.TenantGitMap.GitId == GitMap.GitId && !String.IsNullOrEmpty(m.GitToken)).FirstOrDefault();
+                    if (!String.IsNullOrEmpty(existMap.GitToken))
                     {
                         utrMap.GitToken = existMap.GitToken;
                     }

--- a/web-api/platypus/platypus/DataAccess/Repositories/UserRepository.cs
+++ b/web-api/platypus/platypus/DataAccess/Repositories/UserRepository.cs
@@ -305,26 +305,26 @@ namespace Nssol.Platypus.DataAccess.Repositories
                         UserId = user.Id
                     };
 
-                    //認証情報が空欄のものをはじく
-                    var existMap = GetModelAll<UserTenantGitMap>().Include(m => m.TenantGitMap)
-                        .Where(m => m.UserId == user.Id && m.TenantGitMap.GitId == GitMap.GitId && !String.IsNullOrEmpty(m.GitToken)).FirstOrDefault();
-                    if (existMap != null && !String.IsNullOrEmpty(existMap.GitToken))
+                    // 既存の認証情報存在チェック
+                    var existMap = GetModelAll<UserTenantGitMap>()
+                        .Where(m => m.UserId == user.Id && m.TenantGitMapId == GitMap.Id).FirstOrDefault();
+                    if (existMap != null)
                     {
+                        // 既存の認証情報が存在する場合、再設定する
                         utrMap.GitToken = existMap.GitToken;
                     }
-                    
-                    // UserTenantGitMap において userId と TenantGitMapId のペアが存在しなければエントリ新規追加
-                    var utrMapCount = GetModelAll<UserTenantGitMap>().Where(m => m.UserId == user.Id && m.TenantGitMapId == GitMap.Id).Count();
-                    if (utrMapCount == 0)
+                    else
                     {
+                        // UserTenantGitMap において userId と TenantGitMapId のペアが存在しなければ、エントリ新規追加のためログに出力する
                         LogDebug($"UserTenantGitMap エントリの新規追加 : UserId={user.Id}, TenantGitMapId={GitMap.Id}, TenantId={tenantId}, GitId={GitMap.GitId}");
                     }
+
                     AddModel<UserTenantGitMap>(utrMap);
                 }
 
                 //続いてレジストリの登録
                 //レジストリ登録はクラスタ管理サービスへも影響するので、作成したMapを全て返す
-               
+
                 List<UserTenantRegistryMap> maps = new List<UserTenantRegistryMap>();
 
                 //テナントに紐づいているすべてのレジストリを取得
@@ -337,11 +337,12 @@ namespace Nssol.Platypus.DataAccess.Repositories
                         UserId = user.Id
                     };
 
-                    //認証情報が空欄のものをはじく
-                    var existMap = GetModelAll<UserTenantRegistryMap>().Include(m => m.TenantRegistryMap)
-                        .Where(m => m.UserId == user.Id && m.TenantRegistryMap.RegistryId == registryMap.RegistryId && !String.IsNullOrEmpty(m.RegistryPassword)).FirstOrDefault();
-                    if (existMap != null && !String.IsNullOrEmpty(existMap.RegistryPassword))
+                    // 既存の認証情報存在チェック
+                    var existMap = GetModelAll<UserTenantRegistryMap>()
+                        .Where(m => m.UserId == user.Id && m.TenantRegistryMapId == registryMap.Id).FirstOrDefault();
+                    if (existMap != null)
                     {
+                        // 既存の認証情報が存在する場合、再設定する
                         utrMap.RegistryUserName = existMap.RegistryUserName;
                         utrMap.RegistryPassword = existMap.RegistryPassword;
                     }


### PR DESCRIPTION
#255 に関して対応いたしました。

ユーザ情報更新時にテナントのGit,Registryトークンの情報が空欄のものを参照しないように修正しました。
また、テナント情報更新時にも同様の処理があったため修正しました。

ご確認よろしくお願いします。