### PR TITLE
nvidia docker2のaptキーを更新するように修正

### DIFF
--- a/deploy-tools/infra/roles/gpu-server/tasks/nvidia-docker2.yml
+++ b/deploy-tools/infra/roles/gpu-server/tasks/nvidia-docker2.yml
@@ -3,10 +3,8 @@
     name: nvidia-docker
     state: absent
 
-- name: Add nvidia docker Apt signing key, uses whichever key is at the URL
-  apt_key:
-    url: https://nvidia.github.io/nvidia-docker/gpgkey
-    state: present
+- name: Add or update nvidia docker Apt signing key, uses whichever key is at the URL
+  shell: curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
 
 - name: add nvidia docker apt repo
   get_url:


### PR DESCRIPTION
これまではキー登録がすでにある場合に何もしなかったが、
nvidia-docker2のキーが更新された場合に、aptでエラーが出るようになるので
常に上書きするように修正。（参考：https://nvidia.github.io/nvidia-docker/）