### PR TITLE
デフォルトGit,Registry以外を設定している履歴のコピー時、デフォルトの値でチェックを行わないよう修正

### DIFF
--- a/web-pages/src/components/common/ContainerSelector.vue
+++ b/web-pages/src/components/common/ContainerSelector.vue
@@ -152,7 +152,6 @@
             this.selectedRegistryId = result.defaultRegistryId
             this.model.registryId = result.defaultRegistryId
           }
-          this.getImages() // 新規・コピーどちらの場合も初期値は決まっているので、イメージを取ってくる
         } finally {
           this.listLoading = false
         }

--- a/web-pages/src/components/common/GitSelector.vue
+++ b/web-pages/src/components/common/GitSelector.vue
@@ -208,7 +208,7 @@
       if (this.value) {
         this.setSelectedParameter()
       }
-      await this.getData()
+      await this.getGits()
     },
 
     // 親コンポーネントで、this.valueが変更された場合に呼ばれる処理
@@ -251,8 +251,6 @@
         }
       },
       async getData () {
-        await this.getGits() // Gitサーバ一覧の取得
-
         if (this.selectedGitId !== null) {
           await this.getRepositories() // リポジトリ一覧の再取得
         }


### PR DESCRIPTION
#265 コピー実行時にGit,Registryのチェックでエラーが出ないよう修正

デフォルトGit,Registry以外を設定している履歴のコピー時、デフォルトの値でチェックを行わないよう修正しました。

ご確認よろしくお願いします。