### PR TITLE
jupyter labの起動ディレクトリを/kqi/outputに変更

### DIFF
--- a/web-api/platypus/platypus/Logic/ClusterManagementLogic.cs
+++ b/web-api/platypus/platypus/Logic/ClusterManagementLogic.cs
@@ -984,7 +984,8 @@ namespace Nssol.Platypus.Logic
                 {
                     { "tmp", "/kqi/tmp/" },
                     { "input", "/kqi/input/" },
-                    { "git", "/kqi/git/" }
+                    { "git", "/kqi/git/" },
+                    { "parent", "/kqi/parent/" }
                 },
 
                 PrepareAndFinishContainerEnvList = editableEnvList, // 上書き可の環境変数を設定

--- a/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/notebook_scripts.yaml
+++ b/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/notebook_scripts.yaml
@@ -25,7 +25,16 @@ data:
     else
       pip install jupyterlab==1.0.4
     fi
-    jupyter lab --ip=0.0.0.0 --allow-root --notebook-dir=/kqi/ --no-browser > /kqi/attach/.notebook.log 2>&1 &
+    if [ ! -L /kqi/output/input ]; then
+      ln -s /kqi/input/ /kqi/output/input
+    fi
+    if [ ! -L /kqi/output/git ]; then
+      ln -s /kqi/git/ /kqi/output/git
+    fi
+    if [ ! -L /kqi/output/parent ]; then
+      ln -s /kqi/parent/ /kqi/output/parent
+    fi
+    jupyter lab --ip=0.0.0.0 --allow-root --notebook-dir=/kqi/output --no-browser > /kqi/attach/.notebook.log 2>&1 &
     bash /kqi/scripts/common/wait-ready
   finish: |
     bash /kqi/scripts/common/prepare-kqi-conf

--- a/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/notebook_scripts.yaml
+++ b/web-api/platypus/platypus/ServiceModels/KubernetesModels/Templates/ConfigMap/notebook_scripts.yaml
@@ -21,18 +21,27 @@ data:
     fi
   main: |
     if which pip3 > /dev/null 2>&1; then
-      pip3 install jupyterlab==1.0.4
+        pip3 install jupyterlab==1.0.4
     else
-      pip install jupyterlab==1.0.4
+        pip install jupyterlab==1.0.4
     fi
     if [ ! -L /kqi/output/input ]; then
-      ln -s /kqi/input/ /kqi/output/input
+        ln -s /kqi/input/ /kqi/output/input
+        if [ $? -ne 0 ]; then
+            echo "You change the name of '/kqi/output/input' or delete it, and please run again."
+        fi
     fi
     if [ ! -L /kqi/output/git ]; then
-      ln -s /kqi/git/ /kqi/output/git
+        ln -s /kqi/git/ /kqi/output/git
+        if [ $? -ne 0 ]; then
+            echo "You change the name of '/kqi/output/git' or delete it, and please run again."
+        fi
     fi
     if [ ! -L /kqi/output/parent ]; then
-      ln -s /kqi/parent/ /kqi/output/parent
+        ln -s /kqi/parent/ /kqi/output/parent
+        if [ $? -ne 0 ]; then
+            echo "You change the name of '/kqi/output/parent' or delete it, and please run again."
+        fi
     fi
     jupyter lab --ip=0.0.0.0 --allow-root --notebook-dir=/kqi/output --no-browser > /kqi/attach/.notebook.log 2>&1 &
     bash /kqi/scripts/common/wait-ready


### PR DESCRIPTION
#279 の対応
/kqi/outputを初期ディレクトリとし、/kq/git, /kqi/parent, /kqi/inputへのシンボリックリンクを作成。
初期ディレクトリが/kqi/outputの内部となるため、何も意識せずともファイルを作成、保存すると永続化される。ただし、git, parent, input内にファイルを作成すると、永続化されないことに注意(要マニュアル記述)