### PR TITLE
ユーザ情報に新規テナントを追加した際にデフォルトロールを設定する機能を追加

### DIFF
--- a/web-pages/src/components/system-setting/user/TenantRoleSelector.vue
+++ b/web-pages/src/components/system-setting/user/TenantRoleSelector.vue
@@ -61,9 +61,7 @@
         showSystem: false, // システムロールを表示するか
 
         tenants: [], // 選択されているテナント
-        tenantRoles: [],
-        isSystemRole: false,
-        sortOrder: 0
+        tenantRoles: []
       }
     },
     async created () {
@@ -90,18 +88,14 @@
           this.tenantRoles[0].default = true
         }
 
-        // テナント追加時にデフォルトロール(昇順ソートで最初のロール)を設定
+        // テナント追加時のデフォルトロール設定
         if (this.tenantRoles.length > 0) {
           if (this.tenantRoles[this.tenantRoles.length - 1].roles.length === 0) {
-            let minSortOrder = this.roleTypes.filter(rt => rt.isSystemRole === false)[0].sortOrder
-              for (let i = 0; i < this.roleTypes.length; i++) {
-                // システムロールは除外
-                if (this.roleTypes[i].isSystemRole === false && minSortOrder > this.roleTypes[i].sortOrder) {
-                  minSortOrder = Math.min(minSortOrder, this.roleTypes[i].sortOrder)
-              }
+            // テナントロールで一番最初のロールをデフォルトとして設定する
+            if (this.roleTypes.filter(rt => rt.isSystemRole === false).length > 0) {
+              this.tenantRoles[this.tenantRoles.length - 1].$roles.push(this.roleTypes.filter(rt => rt.isSystemRole === false)[0].id)
+              this.tenantRoles[this.tenantRoles.length - 1].roles = this.roleTypes.filter(rt => rt.isSystemRole === false)
             }
-            this.tenantRoles[this.tenantRoles.length - 1].$roles.push(this.roleTypes.filter(rt => rt.sortOrder === minSortOrder && rt.isSystemRole === false)[0].id)
-            this.tenantRoles[this.tenantRoles.length - 1].roles = this.roleTypes.filter(rt => rt.sortOrder === minSortOrder && rt.isSystemRole === false)
           }
         }
         this.emitInput()

--- a/web-pages/src/components/system-setting/user/TenantRoleSelector.vue
+++ b/web-pages/src/components/system-setting/user/TenantRoleSelector.vue
@@ -61,7 +61,9 @@
         showSystem: false, // システムロールを表示するか
 
         tenants: [], // 選択されているテナント
-        tenantRoles: []
+        tenantRoles: [],
+        isSystemRole: false,
+        sortOrder: 0
       }
     },
     async created () {
@@ -86,6 +88,21 @@
         // default check
         if (this.tenantRoles.length >= 1 && this.tenantRoles.every(tr => tr.default === false)) {
           this.tenantRoles[0].default = true
+        }
+
+        // テナント追加時にデフォルトロール(昇順ソートで最初のロール)を設定
+        if (this.tenantRoles.length > 0) {
+          if (this.tenantRoles[this.tenantRoles.length - 1].roles.length === 0) {
+            let minSortOrder = this.roleTypes.filter(rt => rt.isSystemRole === false)[0].sortOrder
+              for (let i = 0; i < this.roleTypes.length; i++) {
+                // システムロールは除外
+                if (this.roleTypes[i].isSystemRole === false && minSortOrder > this.roleTypes[i].sortOrder) {
+                  minSortOrder = Math.min(minSortOrder, this.roleTypes[i].sortOrder)
+              }
+            }
+            this.tenantRoles[this.tenantRoles.length - 1].$roles.push(this.roleTypes.filter(rt => rt.sortOrder === minSortOrder && rt.isSystemRole === false)[0].id)
+            this.tenantRoles[this.tenantRoles.length - 1].roles = this.roleTypes.filter(rt => rt.sortOrder === minSortOrder && rt.isSystemRole === false)
+          }
         }
         this.emitInput()
       },


### PR DESCRIPTION
#253 ユーザ情報に新規テナントを追加した際にデフォルトでロールが設定される機能を追加しました。

デフォルトとして設定されるロールはロール管理で設定されている表示順の先頭に来るものです。

以上、ご確認よろしくお願いします。