### PR TITLE
マウントする学習一覧取得APIにNotebookからのアクセスを許可

### DIFF
--- a/web-api/platypus/platypus/Controllers/spa/TrainingController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/TrainingController.cs
@@ -180,7 +180,7 @@ namespace Nssol.Platypus.Controllers.spa
         /// </summary>
         /// <param name="filter">検索条件</param>
         [HttpGet("mount")]
-        [Filters.PermissionFilter(MenuCode.Training, MenuCode.Inference)]
+        [Filters.PermissionFilter(MenuCode.Training, MenuCode.Inference, MenuCode.Notebook)]
         [ProducesResponseType(typeof(IEnumerable<IndexOutputModel>), (int)HttpStatusCode.OK)]
         public IActionResult GetTrainingToMount(MountInputModel filter)
         {


### PR DESCRIPTION
#298 について、対応いたしました。

マウントする学習の一覧取得のAPIに、ノートブックからのアクセスを許可していないことが原因です。
そのため、APIにノートブックからのアクセスを許可しました。

ご確認をお願いします。