### PR TITLE
前処理編集の返却するモデルを変更

### DIFF
--- a/web-api/platypus/platypus/Controllers/spa/PreprocessingController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/PreprocessingController.cs
@@ -221,7 +221,7 @@ namespace Nssol.Platypus.Controllers.spa
         /// <param name="preprocessHistoryRepository">DIされる前処理履歴リポジトリ</param>
         [HttpPut("{id}")]
         [PermissionFilter(MenuCode.Preprocess)]
-        [ProducesResponseType(typeof(DetailsOutputModel), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(IndexOutputModel), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> EditDetails(long? id, [FromBody]CreateInputModel model, [FromServices]IPreprocessHistoryRepository preprocessHistoryRepository)
         {
             //データの入力チェック
@@ -255,14 +255,7 @@ namespace Nssol.Platypus.Controllers.spa
             }
             unitOfWork.Commit();
 
-            var result = new DetailsOutputModel(preprocessing);
-            //Gitの表示用URLを作る
-            if (preprocessing.RepositoryGitId != null)
-            {
-                result.GitModel.Url = gitLogic.GetTreeUiUrl(preprocessing.RepositoryGitId.Value, preprocessing.RepositoryName, preprocessing.RepositoryOwner, preprocessing.RepositoryCommitId);
-            }
-
-            return JsonOK(result);
+            return JsonOK(new IndexOutputModel(preprocessing));
         }
 
         /// <summary>


### PR DESCRIPTION
#300 に関して対応いたしました。

前処理編集画面で保存ボタンを押下した際、入力項目でDB値の書き換えを行い、コミットするまでは正常に処理できています。  
しかし、出力用モデルに格納する際のモデルが正しくありません。そのため、nullの項目を設定しようとしてエラーが発生しています。  
`DetailsOutputModel`を返却モデルにしていたが、`IndexOutputModel`を返却するように修正しました。

ご確認をお願いします。