### PR TITLE
学習実行時portListのnullチェックを追加

### DIFF
--- a/web-api/platypus/platypus/Logic/ClusterManagementLogic.cs
+++ b/web-api/platypus/platypus/Logic/ClusterManagementLogic.cs
@@ -526,19 +526,22 @@ namespace Nssol.Platypus.Logic
             }
 
             // 開放するポート番号を指定
-            var portMappingList = new List<PortMappingModel>();
-            foreach (var port in trainHistory.PortList)
-            {
-                var portMappingModel = new PortMappingModel()
+            if (trainHistory.PortList != null)
+            { 
+                var portMappingList = new List<PortMappingModel>();
+                foreach (var port in trainHistory.PortList)
                 {
-                    Protocol = "TCP",
-                    Port = port,
-                    TargetPort = port,
-                    Name = port.ToString()
-                };
-                portMappingList.Add(portMappingModel);
+                    var portMappingModel = new PortMappingModel()
+                    {
+                        Protocol = "TCP",
+                        Port = port,
+                        TargetPort = port,
+                        Name = port.ToString()
+                    };
+                    portMappingList.Add(portMappingModel);
+                }
+                inputModel.PortMappings = portMappingList.ToArray();
             }
-            inputModel.PortMappings = portMappingList.ToArray();
 
             // ユーザの任意追加環境変数をマージする
             AddEnvListToInputModel(trainHistory.OptionDic, inputModel.MainContainerEnvList);

--- a/web-api/platypus/platypus/Migrations/20200319064613_v2.0.0.Designer.cs
+++ b/web-api/platypus/platypus/Migrations/20200319064613_v2.0.0.Designer.cs
@@ -18,7 +18,7 @@ namespace Nssol.Platypus.Migrations
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
-                .HasAnnotation("ProductVersion", "2.1.11-servicing-32099")
+                .HasAnnotation("ProductVersion", "2.1.14-servicing-32113")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             modelBuilder.Entity("Nssol.Platypus.Models.Git", b =>
@@ -1160,6 +1160,8 @@ namespace Nssol.Platypus.Migrations
                     b.Property<string>("Options");
 
                     b.Property<string>("Partition");
+
+                    b.Property<string>("Ports");
 
                     b.Property<DateTime?>("StartedAt");
 

--- a/web-api/platypus/platypus/Migrations/CommonDbContextModelSnapshot.cs
+++ b/web-api/platypus/platypus/Migrations/CommonDbContextModelSnapshot.cs
@@ -16,7 +16,7 @@ namespace Nssol.Platypus.Migrations
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
-                .HasAnnotation("ProductVersion", "2.1.11-servicing-32099")
+                .HasAnnotation("ProductVersion", "2.1.14-servicing-32113")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             modelBuilder.Entity("Nssol.Platypus.Models.Git", b =>
@@ -1158,6 +1158,8 @@ namespace Nssol.Platypus.Migrations
                     b.Property<string>("Options");
 
                     b.Property<string>("Partition");
+
+                    b.Property<string>("Ports");
 
                     b.Property<DateTime?>("StartedAt");
 


### PR DESCRIPTION
#327 のコミット漏れです。
SDKに最新APIモデルを反映したことで、CLIから学習実行しようとすると、portListが設定できないので、nullが入ってしまうため、nullチェックを追加しました。

ご確認をお願いします。