### PR TITLE
前処理履歴詳細画面に作成したデータのID表示、データ編集画面への遷移機能を追加

### DIFF
--- a/web-pages/src/views/preprocessing/HistoryEdit.vue
+++ b/web-pages/src/views/preprocessing/HistoryEdit.vue
@@ -47,6 +47,24 @@
           </el-collapse-item>
         </el-collapse>
       </div>
+      <div v-if="outputDataIds">
+        <el-form-item label="出力データID" />
+        <div v-if="outputDataIds.length >= 11">
+          <el-button type="primary" @click="viewDataIds = !viewDataIds">
+            {{ viewDataIds ? 'Hide DataIds' : 'View All DataIds' }}
+          </el-button>
+        </div>
+        <el-card v-if="outputDataIds.length <= 10 || viewDataIds">
+          <div v-for="(outputDataId, index) in outputDataIds" :key="index">
+            <a
+              href="javascript:void(0)"
+              @click="redirectDataEdit(outputDataId)"
+            >
+              {{ outputDataId }}
+            </a>
+          </div>
+        </el-card>
+      </div>
       <el-row>
         <el-col class="button-group">
           <el-button
@@ -96,6 +114,8 @@ export default {
     return {
       dialogVisible: true,
       preprocessingId: null,
+      viewDataIds: false,
+      outputDataIds: null,
       error: null,
     }
   },
@@ -146,6 +166,7 @@ export default {
           this.error = e
         }
       }
+      this.outputDataIds = this.historyDetail.outputDataIds
     },
 
     async handleRemove() {
@@ -166,6 +187,9 @@ export default {
     },
     emitLog() {
       this.$emit('log', { id: this.id, dataId: this.dataId })
+    },
+    redirectDataEdit(row) {
+      this.$router.push('/data/edit/' + row)
     },
 
     emitCancel() {

--- a/web-pages/src/views/preprocessing/HistoryEdit.vue
+++ b/web-pages/src/views/preprocessing/HistoryEdit.vue
@@ -47,24 +47,24 @@
           </el-collapse-item>
         </el-collapse>
       </div>
-      <div v-if="outputDataIds">
-        <el-form-item label="出力データID" />
+      <el-form-item v-if="outputDataIds" label="出力データID">
         <div v-if="outputDataIds.length >= 11">
           <el-button type="primary" @click="viewDataIds = !viewDataIds">
             {{ viewDataIds ? 'Hide DataIds' : 'View All DataIds' }}
           </el-button>
         </div>
-        <el-card v-if="outputDataIds.length <= 10 || viewDataIds">
-          <div v-for="(outputDataId, index) in outputDataIds" :key="index">
-            <a
-              href="javascript:void(0)"
-              @click="redirectDataEdit(outputDataId)"
-            >
-              {{ outputDataId }}
-            </a>
-          </div>
-        </el-card>
-      </div>
+        <div v-if="outputDataIds.length <= 10 || viewDataIds">
+          <span
+            v-for="(outputDataId, index) in outputDataIds"
+            :key="index"
+            class="outputDataId"
+          >
+            <el-link type="primary" @click="redirectDataEdit(outputDataId)">{{
+              outputDataId
+            }}</el-link>
+          </span>
+        </div>
+      </el-form-item>
       <el-row>
         <el-col class="button-group">
           <el-button
@@ -162,11 +162,13 @@ export default {
             await this.fetchHistoryEvents({ id: this.id, dataId: this.dataId })
           }
           await this.fetchLogFile({ id: this.id, dataId: this.dataId })
+          if (this.historyDetail.outputDataIds.length !== 0) {
+            this.outputDataIds = this.historyDetail.outputDataIds
+          }
         } catch (e) {
           this.error = e
         }
       }
-      this.outputDataIds = this.historyDetail.outputDataIds
     },
 
     async handleRemove() {
@@ -188,8 +190,8 @@ export default {
     emitLog() {
       this.$emit('log', { id: this.id, dataId: this.dataId })
     },
-    redirectDataEdit(row) {
-      this.$router.push('/data/edit/' + row)
+    redirectDataEdit(dataId) {
+      this.$router.push('/data/edit/' + dataId)
     },
 
     emitCancel() {
@@ -219,5 +221,8 @@ export default {
 
 .pull-left {
   float: left !important;
+}
+.outputDataId {
+  margin: 10px;
 }
 </style>


### PR DESCRIPTION
#350 に関して対応いたしました。

前処理履歴詳細画面に作成したデータのIDを表示、対象のIDをクリックすることでデータ編集画面に遷移する機能を追加しました。

ご確認よろしくお願いします。