### PR TITLE
コピー実行時ブランチが切り替わるバグの修正

### DIFF
--- a/web-pages/src/views/inference/Create.vue
+++ b/web-pages/src/views/inference/Create.vue
@@ -483,6 +483,13 @@ export default {
                 ? this.form.gitModel.commit.commitId
                 : this.commits[0].commitId
             }
+            // コピー時ブランチを切り替えずに実行
+            // パラメータに格納する際の形を統一するため整形を行う
+            if (typeof this.form.gitModel.branch.branchName == 'undefined') {
+              let branch = { branchName: this.form.gitModel.branch }
+              this.form.gitModel.branch = branch
+            }
+
             let params = {
               Name: this.form.name,
               DataSetId: this.form.dataSetId,

--- a/web-pages/src/views/inference/Create.vue
+++ b/web-pages/src/views/inference/Create.vue
@@ -485,7 +485,7 @@ export default {
             }
             // コピー時ブランチを切り替えずに実行
             // パラメータに格納する際の形を統一するため整形を行う
-            if (typeof this.form.gitModel.branch.branchName == 'undefined') {
+            if (typeof this.form.gitModel.branch.branchName === 'undefined') {
               let branch = { branchName: this.form.gitModel.branch }
               this.form.gitModel.branch = branch
             }

--- a/web-pages/src/views/notebook/Create.vue
+++ b/web-pages/src/views/notebook/Create.vue
@@ -710,7 +710,7 @@ export default {
         }
         // コピー時ブランチを切り替えずに実行
         // パラメータに格納する際の形を統一するため整形を行う
-        if (typeof this.form.gitModel.branch.branchName == 'undefined') {
+        if (typeof this.form.gitModel.branch.branchName === 'undefined') {
           let branch = { branchName: this.form.gitModel.branch }
           this.form.gitModel.branch = branch
         }

--- a/web-pages/src/views/notebook/Create.vue
+++ b/web-pages/src/views/notebook/Create.vue
@@ -708,6 +708,12 @@ export default {
             ? this.form.gitModel.commit.commitId
             : this.commits[0].commitId
         }
+        // コピー時ブランチを切り替えずに実行
+        // パラメータに格納する際の形を統一するため整形を行う
+        if (typeof this.form.gitModel.branch.branchName == 'undefined') {
+          let branch = { branchName: this.form.gitModel.branch }
+          this.form.gitModel.branch = branch
+        }
         gitModel = {
           gitId: this.form.gitModel.git.id,
           repository: this.form.gitModel.repository.name,

--- a/web-pages/src/views/training/Create.vue
+++ b/web-pages/src/views/training/Create.vue
@@ -468,6 +468,13 @@ export default {
                 ? this.form.gitModel.commit.commitId
                 : this.commits[0].commitId
             }
+            // コピー時ブランチを切り替えずに実行
+            // パラメータに格納する際の形を統一するため整形を行う
+            if (typeof this.form.gitModel.branch.branchName == 'undefined') {
+              let branch = { branchName: this.form.gitModel.branch }
+              this.form.gitModel.branch = branch
+            }
+
             let params = {
               Name: this.form.name,
               DataSetId: this.form.dataSetId,

--- a/web-pages/src/views/training/Create.vue
+++ b/web-pages/src/views/training/Create.vue
@@ -470,7 +470,7 @@ export default {
             }
             // コピー時ブランチを切り替えずに実行
             // パラメータに格納する際の形を統一するため整形を行う
-            if (typeof this.form.gitModel.branch.branchName == 'undefined') {
+            if (typeof this.form.gitModel.branch.branchName === 'undefined') {
               let branch = { branchName: this.form.gitModel.branch }
               this.form.gitModel.branch = branch
             }


### PR DESCRIPTION
#355 に関して対応いたしました。

コピー実行を行う際にブランチが切り替わらないよう修正しました。

ご確認よろしくお願いします。