### PR TITLE
データセット編集画面でのデータのソートを修正

### DIFF
--- a/web-api/platypus/platypus/Controllers/spa/DataSetController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/DataSetController.cs
@@ -134,7 +134,13 @@ namespace Nssol.Platypus.Controllers.spa
                 {
                     string key = entry.DataType.Name;
                     var dataFile = new ApiModels.DataApiModels.IndexOutputModel(entry.Data);
-                    entities[key].Insert(0, dataFile);
+                    entities[key].Add(dataFile);
+                }
+
+                //各種別内のデータについて、データIDの降順に並び替える
+                foreach (var dataType in dataTypeRepository.GetAllWithOrderby(d => d.SortOrder, true))
+                {
+                    entities[dataType.Name].Reverse();
                 }
 
                 model.Entries = entities;

--- a/web-api/platypus/platypus/Controllers/spa/DataSetController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/DataSetController.cs
@@ -134,7 +134,7 @@ namespace Nssol.Platypus.Controllers.spa
                 {
                     string key = entry.DataType.Name;
                     var dataFile = new ApiModels.DataApiModels.IndexOutputModel(entry.Data);
-                    entities[key].Add(dataFile);
+                    entities[key].Insert(0, dataFile);
                 }
 
                 model.Entries = entities;

--- a/web-pages/src/views/dataSet/DatasetTransfer/Index.vue
+++ b/web-pages/src/views/dataSet/DatasetTransfer/Index.vue
@@ -240,7 +240,13 @@ export default {
         entry.length,
       )
       let dataList = entry.slice(pageStartIndex, pageEndIndex)
-
+      dataList.sort(function(a, b) {
+        if (a.id < b.id) {
+          return 1
+        } else {
+          return -1
+        }
+      })
       viewInfo.currentPage = nextPage
       viewInfo.dataList = dataList
       viewInfo.filteredTotal = entry.length

--- a/web-pages/src/views/dataSet/DatasetTransfer/Index.vue
+++ b/web-pages/src/views/dataSet/DatasetTransfer/Index.vue
@@ -240,13 +240,6 @@ export default {
         entry.length,
       )
       let dataList = entry.slice(pageStartIndex, pageEndIndex)
-      dataList.sort(function(a, b) {
-        if (a.id < b.id) {
-          return 1
-        } else {
-          return -1
-        }
-      })
       viewInfo.currentPage = nextPage
       viewInfo.dataList = dataList
       viewInfo.filteredTotal = entry.length


### PR DESCRIPTION
#100 に関して対応いたしました。

データセット編集画面でのデータを全てデータID降順でソートするように修正しました。

ご確認よろしくお願いします。