### PR TITLE
前処理実行画面を閉じた後他の画面が開けなくならないように修正

### DIFF
--- a/web-pages/src/views/preprocessing/Index.vue
+++ b/web-pages/src/views/preprocessing/Index.vue
@@ -71,6 +71,7 @@
     <router-view
       @done="done"
       @cancel="closeDialog"
+      @close="closeDialog"
       @copy="handleCopy"
       @return="back"
       @shell="shell"


### PR DESCRIPTION
#380 に関して対応いたしました。

前処理実行画面をｘボタンで閉じた後に実行画面を開いてもエラーページに遷移しないよう修正しました。

ご確認よろしくお願いします。