### PR TITLE
開放ポート未指定時、serviceの問い合わせを行わないよう修正

### DIFF
--- a/web-api/platypus/platypus/Controllers/spa/TrainingController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/TrainingController.cs
@@ -337,11 +337,15 @@ namespace Nssol.Platypus.Controllers.spa
                 model.ConditionNote = details.ConditionNote;
                 if (details.Status.IsRunning())
                 {
-                    var endpointInfo = await clusterManagementLogic.GetContainerEndpointInfoAsync(history.Key, CurrentUserInfo.SelectedTenant.Name, false);
-                    foreach (var endpoint in endpointInfo.EndPoints ?? new List<EndPointInfo>())
+                    // 開放ポート未指定時には行わない
+                    if (model.Ports != null && model.Ports.Count > 0)
                     {
-                        //ノードポート番号を返す
-                        model.NodePorts.Add(new KeyValuePair<string, string>(endpoint.Key, endpoint.Port.ToString()));
+                        var endpointInfo = await clusterManagementLogic.GetContainerEndpointInfoAsync(history.Key, CurrentUserInfo.SelectedTenant.Name, false);
+                        foreach (var endpoint in endpointInfo.EndPoints ?? new List<EndPointInfo>())
+                        {
+                            //ノードポート番号を返す
+                            model.NodePorts.Add(new KeyValuePair<string, string>(endpoint.Key, endpoint.Port.ToString()));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#382 関して対応いたしました。

開放ポート未指定の学習履歴を閲覧時、serviceへの問い合わせを行わないよう修正しました。

ご確認よろしくお願いします。