### PR TITLE
ヘッダー部分のユーザー・テナント名が長い場合省略して表示するよう修正

### DIFF
--- a/web-pages/src/components/KqiHeader.vue
+++ b/web-pages/src/components/KqiHeader.vue
@@ -84,6 +84,13 @@ export default {
       if (tenant) {
         await this.fetchAccount()
         this.user = this.account
+        if (this.user.userName.length > 25) {
+          this.user.userName = this.user.userName.substr(0, 25) + '...'
+        }
+        if (this.user.selectedTenant.displayName.length > 25) {
+          this.user.selectedTenant.displayName =
+            this.user.selectedTenant.displayName.substr(0, 25) + '...'
+        }
       } else {
         this.user = null
       }


### PR DESCRIPTION
#384 に関して対応いたしました。

ヘッダー部分のユーザー・テナント名が長い場合省略して表示するように修正しました。

ご確認よろしくお願いします。