### PR TITLE
gitbucketのapi url登録時に/api/v3を付けないといけないのをなくす

### DIFF
--- a/web-api/platypus/platypus/Services/GitBucketService.cs
+++ b/web-api/platypus/platypus/Services/GitBucketService.cs
@@ -89,5 +89,22 @@ namespace Nssol.Platypus.Services
                 }
             }
         }
+
+        /// <summary>
+        /// 共通で使うパラメータを生成
+        /// </summary>
+        /// <param name="gitMap">Git情報</param>
+        /// <returns>リクエストパラメータ</returns>
+        protected override RequestParam CreateRequestParam(UserTenantGitMap gitMap)
+        {
+            RequestParam param = new RequestParam()
+            {
+                BaseUrl = gitMap.Git.ApiUrl.TrimEnd('/')+"/api/v3",
+                Token = gitMap.GitToken,
+                UserAgent = "C#App",
+                TokenType = "token",
+            };
+            return param;
+        }
     }
 }

--- a/web-api/platypus/platypus/Services/GitHubService.cs
+++ b/web-api/platypus/platypus/Services/GitHubService.cs
@@ -242,7 +242,7 @@ namespace Nssol.Platypus.Services
         /// </summary>
         /// <param name="gitMap">Git情報</param>
         /// <returns>リクエストパラメータ</returns>
-        protected RequestParam CreateRequestParam(UserTenantGitMap gitMap)
+        protected virtual RequestParam CreateRequestParam(UserTenantGitMap gitMap)
         {
             RequestParam param = new RequestParam()
             {


### PR DESCRIPTION
gitlab登録ではgitlabのapiエンドポイントのパス/api/v4を自動付与しますが、
gitbucketはgithubのコードを流用している関係でgitbucketのapiエンドポイントのパス/api/v3を自動付与されない状態でした