### PR TITLE
テンプレートカードの説明文の改行を修正issue #540

### DIFF
--- a/web-pages-aquarium/src/views/modelTemplate/Index.vue
+++ b/web-pages-aquarium/src/views/modelTemplate/Index.vue
@@ -47,7 +47,7 @@
 
                   <div
                     class="template-description"
-                    style="padding: 10px; font-size: 14px; z-index :100;"
+                    style="padding: 10px; font-size: 14px; z-index :100; white-space: break-spaces;"
                   >
                     <span v-for="(s, i) in template.memoList" :key="i">
                       <span v-if="s.type == 'url'" style="font-size:15px">


### PR DESCRIPTION
以下について対応してみました。
issue #540

修正内容。
カード内の説明文にて<span>タグではデフォルトで改行されないため、スタイルに`white-space`属性を追記しました。