### PR TITLE
クォータ管理画面の最大値をCPU200→250、メモリ200→500に修正

### DIFF
--- a/web-pages/src/views/system-setting/quota/Index.vue
+++ b/web-pages/src/views/system-setting/quota/Index.vue
@@ -24,7 +24,7 @@
               v-model="scope.row.cpu"
               size="small"
               :min="0"
-              :max="200"
+              :max="250"
               controls-position="right"
             />
           </template>
@@ -34,7 +34,7 @@
             <el-input-number
               v-model="scope.row.memory"
               :min="0"
-              :max="200"
+              :max="500"
               size="small"
               controls-position="right"
             />


### PR DESCRIPTION
アクアリウムの方はシステム設定のメニューを削除するので修正していません