### PR TITLE
web-api-Dockerfileをdotnet core 3.1に対応するため更新

### DIFF
--- a/release-tools/build-docker/web-api-Dockerfile
+++ b/release-tools/build-docker/web-api-Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
-RUN dotnet tool install --global dotnet-ef --version 3.1.19
+RUN dotnet tool install --global dotnet-ef
 COPY /platypus/platypus /src/
 ARG version
 RUN cd /src/  && \    

--- a/release-tools/build-docker/web-api-Dockerfile
+++ b/release-tools/build-docker/web-api-Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 3.1.19
 COPY /platypus/platypus /src/
 ARG version
 RUN cd /src/  && \    

--- a/release-tools/build-docker/web-api-Dockerfile
+++ b/release-tools/build-docker/web-api-Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
-RUN dotnet tool install dotnetsay --version 3.1.2
+RUN dotnet tool install --global dotnet-ef --version 3.1.19
 COPY /platypus/platypus /src/
 ARG version
 RUN cd /src/  && \    

--- a/release-tools/build-docker/web-api-Dockerfile
+++ b/release-tools/build-docker/web-api-Dockerfile
@@ -1,10 +1,11 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+RUN dotnet tool install dotnetsay --version 3.1.2
 COPY /platypus/platypus /src/
 ARG version
 RUN cd /src/  && \    
     dotnet publish -c Release -o /output /p:InformationalVersion=$version
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 RUN groupadd -r -g 800 platypus-api && \
     useradd -r -s /bin/false -g platypus-api -u 800 platypus-api
 COPY --from=build /output /app


### PR DESCRIPTION
web-api-Dockerfileをdotnet core 3.1に対応するため更新。

以下に関連。
- https://github.com/KAMONOHASHI/kamonohashi/pull/566