### PR TITLE
notebook機能のデフォルトイメージの変更

### DIFF
--- a/release-tools/README.md
+++ b/release-tools/README.md
@@ -1,19 +1,31 @@
 # リリース手順
-## リリースするソースコードの指定
-* GitHubでバージョン名リリースを作成(テストが終わるまでプレリリース)
-  * 例: 1.0.1
-* git fetch upstream && git merge upstream/(バージョンブランチ) を実行
-  * 例: git merge upstream/1.0
-## コンテナのビルド & リリース
-* build-docker/build.shの実行
-* docker loginでDockerHubにログイン
-* build-docker/push.shの実行
-## Python Packageのビルド & リリース
-* build-pypi/setup.sh build の実行
-* PyPiにログイン
-* build-pypi/setup.sh test-upload の実行
-* pip installの確認
-* build-pypi/setup.sh master-upload の実行
 
-# developリリース
-* tagをつけずに`build-docker/build.sh`を実行するとdevelopタグでコンテナが作られる
+## リリースするソースコードの指定
+
+- GitHub でバージョン名リリースを作成(テストが終わるまでプレリリース)
+  - 例: 1.0.1
+- git fetch upstream && git merge upstream/(バージョンブランチ) を実行
+  - 例: git merge upstream/1.0
+
+## コンテナのビルド & リリース
+
+- build-docker/build.sh の実行
+- docker login で DockerHub にログイン
+- build-docker/push.sh の実行
+
+## Python Package のビルド & リリース
+
+- build-pypi/setup.sh build の実行
+- PyPi にログイン
+- build-pypi/setup.sh test-upload の実行
+- pip install の確認
+- build-pypi/setup.sh master-upload の実行
+
+# develop リリース
+
+- tag をつけずに`build-docker/build.sh`を実行すると develop タグでコンテナが作られる
+
+# Notebook Image のビルド & リリース
+
+ノートブック機能のデフォルトイメージを作成するための Dockerfile が`build-notebook-image`に配置されている。
+毎回のリリースごとには実施せず、Python のマイナーバージョンのサポート終了や、コンテナ内で利用するパッケージに破壊的な変更が入った場合等にリリースを行う。

--- a/release-tools/build-notebook-image/Dockerfile
+++ b/release-tools/build-notebook-image/Dockerfile
@@ -1,0 +1,5 @@
+FROM tensorflow/tensorflow:2.9.0-gpu
+
+RUN pip install --upgrade pip \
+    && pip install jupyterlab \
+    && pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113

--- a/web-api/platypus/platypus/Controllers/spa/NotebookController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/NotebookController.cs
@@ -534,7 +534,7 @@ namespace Nssol.Platypus.Controllers.spa
                 //コンテナイメージの設定がない場合デフォルトのイメージを設定
                 notebookHistory.ContainerRegistryId = null;
                 notebookHistory.ContainerImage = "kamonohashi/jupyterlab";
-                notebookHistory.ContainerTag = "tensorflow-2.9.0";
+                notebookHistory.ContainerTag = "tensorflow-2.9-pytorch-1.12";
             }
 
             //gitが指定されているかチェック
@@ -807,7 +807,7 @@ namespace Nssol.Platypus.Controllers.spa
                 // コンテナイメージの設定がない場合デフォルトのイメージを設定
                 notebookHistory.ContainerRegistryId = null;
                 notebookHistory.ContainerImage = "kamonohashi/jupyterlab";
-                notebookHistory.ContainerTag = "tensorflow-2.9.0";
+                notebookHistory.ContainerTag = "tensorflow-2.9-pytorch-1.12";
             }
             // gitが指定されているかチェック
             if (model.GitModel != null)

--- a/web-api/platypus/platypus/Controllers/spa/NotebookController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/NotebookController.cs
@@ -571,7 +571,7 @@ namespace Nssol.Platypus.Controllers.spa
             if (string.IsNullOrEmpty(notebookHistory.JupyterLabVersion))
             {
                 // null または 空文字 の場合はデフォルトのバージョンを指定
-                notebookHistory.JupyterLabVersion = "2.3.1";
+                notebookHistory.JupyterLabVersion = "3.4.2";
             }
 
             if (notebookHistory.OptionDic.ContainsKey("")) //空文字は除外する
@@ -852,7 +852,7 @@ namespace Nssol.Platypus.Controllers.spa
             if (string.IsNullOrEmpty(model.JupyterLabVersion))
             {
                 // null または 空文字 の場合はデフォルトのバージョンを指定
-                notebookHistory.JupyterLabVersion = "2.3.1";
+                notebookHistory.JupyterLabVersion = "3.4.2";
             }
             else
             {

--- a/web-api/platypus/platypus/Controllers/spa/NotebookController.cs
+++ b/web-api/platypus/platypus/Controllers/spa/NotebookController.cs
@@ -534,7 +534,7 @@ namespace Nssol.Platypus.Controllers.spa
                 //コンテナイメージの設定がない場合デフォルトのイメージを設定
                 notebookHistory.ContainerRegistryId = null;
                 notebookHistory.ContainerImage = "kamonohashi/jupyterlab";
-                notebookHistory.ContainerTag = "tensorflow-2.2.0";
+                notebookHistory.ContainerTag = "tensorflow-2.9.0";
             }
 
             //gitが指定されているかチェック
@@ -807,7 +807,7 @@ namespace Nssol.Platypus.Controllers.spa
                 // コンテナイメージの設定がない場合デフォルトのイメージを設定
                 notebookHistory.ContainerRegistryId = null;
                 notebookHistory.ContainerImage = "kamonohashi/jupyterlab";
-                notebookHistory.ContainerTag = "tensorflow-2.2.0";
+                notebookHistory.ContainerTag = "tensorflow-2.9.0";
             }
             // gitが指定されているかチェック
             if (model.GitModel != null)

--- a/web-pages/src/views/notebook/Create.vue
+++ b/web-pages/src/views/notebook/Create.vue
@@ -512,8 +512,8 @@ export default {
       isReRunCreation: false,
       jupyterLabInfo: {
         description:
-          'デフォルト: 2.3.1 (JupyterLabがインストール済みのコンテナイメージでは選択してもスキップされます)',
-        defaultVersion: 'デフォルト: 2.3.1',
+          'デフォルト: 3.4.2 (JupyterLabがインストール済みのコンテナイメージでは選択してもスキップされます)',
+        defaultVersion: 'デフォルト: 3.4.2',
       },
     }
   },


### PR DESCRIPTION
notebookのデフォルトイメージのバージョンを上げた。[Docker Image (dockerhub)](https://hub.docker.com/layers/kamonohashi/jupyterlab/tensorflow-2.9-pytorch-1.12/images/sha256-69234592e167621e3f49aaec8b87c94d18d59a799512ff8bc3167e6b155b741a?context=explore)

# 情報
- python 3.8.10
- tensorflow 2.9.0
- pytorch 1.12.0
- jupyterlab 3.4.2